### PR TITLE
Static reflection based data mapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,18 @@ set(CMAKE_COLOR_DIAGNOSTICS ON)
 include(ClangTidy)
 include(PedanticCompiler)
 
+# download CPM.cmake
+file(
+    DOWNLOAD
+    https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.38.3/CPM.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM.cmake
+    EXPECTED_HASH SHA256=cc155ce02e7945e7b8967ddfaff0b050e958a723ef7aad3766d368940cb15494
+)
+include(${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM.cmake)
+
+# TODO: use a release version of reflection-cpp as soon as possible
+CPMAddPackage("gh:contour-terminal/reflection-cpp#master")
+
 if(NOT WIN32 AND NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Choose the build mode." FORCE)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release MinSizeRel RelWithDebInfo)

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -71,6 +71,8 @@ IncludeCategories:
     Priority:  0
   - Regex:     '^<(Lightweight)/'
     Priority:  10
+  - Regex:     '^<(reflection-cpp)/'
+    Priority:  20
   - Regex:     '^<gsl/'
     Priority:  48
   - Regex:     '^<catch2/'

--- a/src/Lightweight/CMakeLists.txt
+++ b/src/Lightweight/CMakeLists.txt
@@ -45,6 +45,12 @@ set(HEADER_FILES
     SqlQuery/Select.hpp
     SqlQuery/Update.hpp
 
+    DataMapper/DataMapper.hpp
+    DataMapper/Detail.hpp
+    DataMapper/Field.hpp
+    DataMapper/Logger.hpp
+    DataMapper/RecordId.hpp
+
     SqlConnectInfo.hpp
     SqlConnection.hpp
     SqlError.hpp
@@ -59,6 +65,9 @@ set(SOURCE_FILES
     DataBinder/SqlGuid.cpp
     DataBinder/SqlVariant.cpp
     DataBinder/UnicodeConverter.cpp
+
+    DataMapper/Logger.cpp
+
     SqlConnectInfo.cpp
     SqlConnection.cpp
     SqlError.cpp
@@ -106,6 +115,8 @@ target_include_directories(Lightweight PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/..>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include>
 )
+
+target_link_libraries(Lightweight PUBLIC reflection-cpp::reflection-cpp)
 
 if(MSVC)
     target_compile_options(Lightweight PRIVATE /W4 /WX)

--- a/src/Lightweight/DataMapper/Associations/BelongsTo.hpp
+++ b/src/Lightweight/DataMapper/Associations/BelongsTo.hpp
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "../../SqlStatement.hpp"
+#include "../AbstractField.hpp"
+#include "../AbstractRecord.hpp"
+#include "../ColumnType.hpp"
+#include "../RecordId.hpp"
+#include "../StringLiteral.hpp"
+
+#include <cassert>
+#include <memory>
+#include <string_view>
+
+namespace Model
+{
+
+template <typename T>
+struct Record;
+
+// Represents a column in a table that is a foreign key to another table.
+template <typename OtherRecord,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement = FieldValueRequirement::NOT_NULL>
+class BelongsTo final: public AbstractField
+{
+  public:
+    constexpr static inline SQLSMALLINT ColumnIndex { TheColumnIndex };
+    constexpr static inline std::string_view ColumnName { TheForeignKeyName.value };
+
+    explicit BelongsTo(AbstractRecord& record);
+    BelongsTo(BelongsTo const& other);
+    explicit BelongsTo(AbstractRecord& record, BelongsTo&& other);
+    BelongsTo& operator=(RecordId modelId);
+    BelongsTo& operator=(OtherRecord const& model);
+    ~BelongsTo() override = default;
+
+    OtherRecord* operator->();
+    OtherRecord& operator*();
+
+    [[nodiscard]] std::string SqlConstraintSpecifier() const override;
+
+    [[nodiscard]] std::string InspectValue() const override;
+    void BindInputParameter(SQLSMALLINT parameterIndex, SqlStatement& stmt) const override;
+    void BindOutputColumn(SqlStatement& stmt) override;
+    void BindOutputColumn(SQLSMALLINT index, SqlStatement& stmt) override;
+    void LoadValueFrom(AbstractField& other) override;
+
+    auto operator<=>(BelongsTo const& other) const noexcept;
+
+    template <typename U, SQLSMALLINT I, StringLiteral N, FieldValueRequirement R>
+    bool operator==(BelongsTo<U, I, N, R> const& other) const noexcept;
+
+    template <typename U, SQLSMALLINT I, StringLiteral N, FieldValueRequirement R>
+    bool operator!=(BelongsTo<U, I, N, R> const& other) const noexcept;
+
+    void Load() noexcept;
+
+  private:
+    void RequireLoaded();
+
+    RecordId m_value {};
+    std::shared_ptr<OtherRecord> m_otherRecord;
+
+    // We decided to use shared_ptr here, because we do not want to require to know the size of the OtherRecord
+    // at declaration time.
+};
+
+// {{{ BelongsTo<> implementation
+
+template <typename Model,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement>
+BelongsTo<Model, TheColumnIndex, TheForeignKeyName, TheRequirement>::BelongsTo(AbstractRecord& record):
+    AbstractField {
+        record, TheColumnIndex, TheForeignKeyName.value, ColumnTypeOf<RecordId>, TheRequirement,
+    }
+{
+    record.RegisterField(*this);
+}
+
+template <typename Model,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement>
+BelongsTo<Model, TheColumnIndex, TheForeignKeyName, TheRequirement>::BelongsTo(BelongsTo const& other):
+    AbstractField {
+        const_cast<BelongsTo&>(other).GetRecord(),
+        TheColumnIndex,
+        TheForeignKeyName.value,
+        ColumnTypeOf<RecordId>,
+        TheRequirement,
+    },
+    m_value { other.m_value }
+{
+    GetRecord().RegisterField(*this);
+}
+
+template <typename Model,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement>
+BelongsTo<Model, TheColumnIndex, TheForeignKeyName, TheRequirement>::BelongsTo(AbstractRecord& record,
+                                                                               BelongsTo&& other):
+    AbstractField { std::move(static_cast<AbstractField&&>(other)) },
+    m_value { std::move(other.m_value) }
+{
+    record.RegisterField(*this);
+}
+
+template <typename Model,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement>
+BelongsTo<Model, TheColumnIndex, TheForeignKeyName, TheRequirement>&
+BelongsTo<Model, TheColumnIndex, TheForeignKeyName, TheRequirement>::operator=(RecordId modelId)
+{
+    SetModified(true);
+    m_value = modelId;
+    return *this;
+}
+
+template <typename OtherRecord,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement>
+BelongsTo<OtherRecord, TheColumnIndex, TheForeignKeyName, TheRequirement>&
+BelongsTo<OtherRecord, TheColumnIndex, TheForeignKeyName, TheRequirement>::operator=(OtherRecord const& model)
+{
+    SetModified(true);
+    m_value = model.Id();
+    return *this;
+}
+
+template <typename OtherRecord,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement>
+inline OtherRecord* BelongsTo<OtherRecord, TheColumnIndex, TheForeignKeyName, TheRequirement>::operator->()
+{
+    RequireLoaded();
+    return &*m_otherRecord;
+}
+
+template <typename OtherRecord,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement>
+inline OtherRecord& BelongsTo<OtherRecord, TheColumnIndex, TheForeignKeyName, TheRequirement>::operator*()
+{
+    RequireLoaded();
+    return *m_otherRecord;
+}
+
+template <typename OtherRecord,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement>
+std::string BelongsTo<OtherRecord, TheColumnIndex, TheForeignKeyName, TheRequirement>::SqlConstraintSpecifier() const
+{
+    auto const otherRecord = OtherRecord {};
+    // TODO: Move the syntax into SqlTraits, as a parametrized member function
+    return std::format("FOREIGN KEY ({}) REFERENCES {}({}) ON DELETE CASCADE",
+                       ColumnName,
+                       otherRecord.TableName(),
+                       otherRecord.PrimaryKeyName());
+}
+
+template <typename OtherRecord,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement>
+inline std::string BelongsTo<OtherRecord, TheColumnIndex, TheForeignKeyName, TheRequirement>::InspectValue() const
+{
+    return std::to_string(m_value.value);
+}
+
+template <typename OtherRecord,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement>
+inline void BelongsTo<OtherRecord, TheColumnIndex, TheForeignKeyName, TheRequirement>::BindInputParameter(
+    SQLSMALLINT parameterIndex, SqlStatement& stmt) const
+{
+    return stmt.BindInputParameter(parameterIndex, m_value.value);
+}
+
+template <typename OtherRecord,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement>
+inline void BelongsTo<OtherRecord, TheColumnIndex, TheForeignKeyName, TheRequirement>::BindOutputColumn(
+    SqlStatement& stmt)
+{
+    return stmt.BindOutputColumn(TheColumnIndex, &m_value.value);
+}
+
+template <typename OtherRecord,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement>
+inline void BelongsTo<OtherRecord, TheColumnIndex, TheForeignKeyName, TheRequirement>::BindOutputColumn(
+    SQLSMALLINT outputIndex, SqlStatement& stmt)
+{
+    return stmt.BindOutputColumn(outputIndex, &m_value.value);
+}
+
+template <typename OtherRecord,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement>
+void BelongsTo<OtherRecord, TheColumnIndex, TheForeignKeyName, TheRequirement>::LoadValueFrom(AbstractField& other)
+{
+    assert(Type() == other.Type());
+    m_value = std::move(static_cast<BelongsTo&>(other).m_value);
+    m_otherRecord.reset();
+}
+
+template <typename OtherRecord,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement>
+inline auto BelongsTo<OtherRecord, TheColumnIndex, TheForeignKeyName, TheRequirement>::operator<=>(
+    BelongsTo const& other) const noexcept
+{
+    return m_value <=> other.m_value;
+}
+
+template <typename OtherRecord,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement>
+template <typename U, SQLSMALLINT I, StringLiteral N, FieldValueRequirement R>
+inline bool BelongsTo<OtherRecord, TheColumnIndex, TheForeignKeyName, TheRequirement>::operator==(
+    BelongsTo<U, I, N, R> const& other) const noexcept
+{
+    return m_value == other.m_value;
+}
+
+template <typename OtherRecord,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement>
+template <typename U, SQLSMALLINT I, StringLiteral N, FieldValueRequirement R>
+inline bool BelongsTo<OtherRecord, TheColumnIndex, TheForeignKeyName, TheRequirement>::operator!=(
+    BelongsTo<U, I, N, R> const& other) const noexcept
+{
+    return m_value == other.m_value;
+}
+
+template <typename OtherRecord,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement>
+void BelongsTo<OtherRecord, TheColumnIndex, TheForeignKeyName, TheRequirement>::Load() noexcept
+{
+    if (m_otherRecord)
+        return;
+
+    auto otherRecord = OtherRecord::Find(m_value);
+    if (otherRecord.has_value())
+        m_otherRecord = std::make_shared<OtherRecord>(std::move(otherRecord.value()));
+}
+
+template <typename OtherRecord,
+          SQLSMALLINT TheColumnIndex,
+          StringLiteral TheForeignKeyName,
+          FieldValueRequirement TheRequirement>
+inline void BelongsTo<OtherRecord, TheColumnIndex, TheForeignKeyName, TheRequirement>::RequireLoaded()
+{
+    if (!m_otherRecord)
+    {
+        Load();
+        if (!m_otherRecord)
+            throw std::runtime_error("BelongsTo::RequireLoaded(): Record not found");
+    }
+}
+
+// }}}
+
+} // namespace Model

--- a/src/Lightweight/DataMapper/Associations/HasMany.hpp
+++ b/src/Lightweight/DataMapper/Associations/HasMany.hpp
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "../../SqlError.hpp"
+#include "../AbstractRecord.hpp"
+#include "../Logger.hpp"
+#include "../StringLiteral.hpp"
+
+#include <vector>
+
+namespace Model
+{
+
+template <typename OtherRecord, StringLiteral ForeignKeyName>
+class HasMany
+{
+  public:
+    explicit HasMany(AbstractRecord& parent);
+    HasMany(AbstractRecord& record, HasMany&& other) noexcept;
+
+    [[nodiscard]] bool IsEmpty() const;
+    [[nodiscard]] size_t Count() const;
+
+    std::vector<OtherRecord>& All();
+
+    OtherRecord& At(size_t index);
+    OtherRecord& operator[](size_t index);
+
+    [[nodiscard]] bool IsLoaded() const noexcept;
+    void Load();
+    void Reload();
+
+  private:
+    bool RequireLoaded();
+
+    bool m_loaded = false;
+    AbstractRecord* m_record;
+    std::vector<OtherRecord> m_models;
+};
+
+// {{{ HasMany<> implementation
+
+template <typename OtherRecord, StringLiteral ForeignKeyName>
+HasMany<OtherRecord, ForeignKeyName>::HasMany(AbstractRecord& parent):
+    m_record { &parent }
+{
+}
+
+template <typename OtherRecord, StringLiteral ForeignKeyName>
+HasMany<OtherRecord, ForeignKeyName>::HasMany(AbstractRecord& record, HasMany&& other) noexcept:
+    m_loaded { other.m_loaded },
+    m_record { &record },
+    m_models { std::move(other.m_models) }
+{
+}
+
+template <typename OtherRecord, StringLiteral ForeignKeyName>
+void HasMany<OtherRecord, ForeignKeyName>::Load()
+{
+    if (m_loaded)
+        return;
+
+    m_models = OtherRecord::Where(*ForeignKeyName, m_record->Id()).All();
+    m_loaded = true;
+}
+
+template <typename OtherRecord, StringLiteral ForeignKeyName>
+void HasMany<OtherRecord, ForeignKeyName>::Reload()
+{
+    m_loaded = false;
+    m_models.clear();
+    return Load();
+}
+
+template <typename OtherRecord, StringLiteral ForeignKeyName>
+bool HasMany<OtherRecord, ForeignKeyName>::IsEmpty() const
+{
+    return Count() == 0;
+}
+
+template <typename OtherRecord, StringLiteral ForeignKeyName>
+size_t HasMany<OtherRecord, ForeignKeyName>::Count() const
+{
+    if (m_loaded)
+        return m_models.size();
+
+    SqlStatement stmt;
+
+    auto const sqlQueryString = std::format(
+        "SELECT COUNT(*) FROM {} WHERE {} = {}", OtherRecord().TableName(), *ForeignKeyName, *m_record->Id());
+    auto const scopedModelSqlLogger = detail::SqlScopedModelQueryLogger(sqlQueryString, {});
+    return stmt.ExecuteDirectScalar<size_t>(sqlQueryString).value();
+}
+
+template <typename OtherRecord, StringLiteral ForeignKeyName>
+inline std::vector<OtherRecord>& HasMany<OtherRecord, ForeignKeyName>::All()
+{
+    RequireLoaded();
+    return m_models;
+}
+
+template <typename OtherRecord, StringLiteral ForeignKeyName>
+inline OtherRecord& HasMany<OtherRecord, ForeignKeyName>::At(size_t index)
+{
+    RequireLoaded();
+    return m_models.at(index);
+}
+
+template <typename OtherRecord, StringLiteral ForeignKeyName>
+inline OtherRecord& HasMany<OtherRecord, ForeignKeyName>::operator[](size_t index)
+{
+    RequireLoaded();
+    return m_models[index];
+}
+
+template <typename OtherRecord, StringLiteral ForeignKeyName>
+inline bool HasMany<OtherRecord, ForeignKeyName>::IsLoaded() const noexcept
+{
+    return m_loaded;
+}
+
+template <typename OtherRecord, StringLiteral ForeignKeyName>
+inline bool HasMany<OtherRecord, ForeignKeyName>::RequireLoaded()
+{
+    if (!m_loaded)
+        Load();
+
+    return m_loaded;
+}
+
+// }}}
+
+} // namespace Model

--- a/src/Lightweight/DataMapper/Associations/HasManyThrough.hpp
+++ b/src/Lightweight/DataMapper/Associations/HasManyThrough.hpp
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "../../SqlComposedQuery.hpp"
+#include "../AbstractRecord.hpp"
+#include "../StringLiteral.hpp"
+
+namespace Model
+{
+
+template <typename TargetRecord, StringLiteral LeftKeyName, typename ThroughRecord, StringLiteral RightKeyName>
+class HasManyThrough
+{
+  public:
+    explicit HasManyThrough(AbstractRecord& record);
+    explicit HasManyThrough(AbstractRecord& record, HasManyThrough&& other) noexcept;
+
+    [[nodiscard]] bool IsEmpty() const noexcept;
+    [[nodiscard]] size_t Count() const;
+
+    std::vector<TargetRecord>& All();
+
+    template <typename Callback>
+    void Each(Callback&& callback);
+
+    TargetRecord& At(size_t index);
+    TargetRecord const& At(size_t index) const;
+    TargetRecord& operator[](size_t index);
+    TargetRecord const& operator[](size_t index) const;
+
+    [[nodiscard]] bool IsLoaded() const noexcept;
+    void Load();
+    void Reload();
+
+  private:
+    void RequireLoaded() const;
+
+    AbstractRecord* m_record;
+    bool m_loaded = false;
+    std::vector<TargetRecord> m_models;
+};
+
+// {{{ inlines
+
+template <typename TargetRecord, StringLiteral LeftKeyName, typename ThroughRecord, StringLiteral RightKeyName>
+HasManyThrough<TargetRecord, LeftKeyName, ThroughRecord, RightKeyName>::HasManyThrough(AbstractRecord& record):
+    m_record { &record }
+{
+}
+
+template <typename TargetRecord, StringLiteral LeftKeyName, typename ThroughRecord, StringLiteral RightKeyName>
+HasManyThrough<TargetRecord, LeftKeyName, ThroughRecord, RightKeyName>::HasManyThrough(AbstractRecord& record,
+                                                                                       HasManyThrough&& other) noexcept:
+    m_record { &record },
+    m_loaded { other.m_loaded },
+    m_models { std::move(other.m_models) }
+{
+}
+
+template <typename TargetRecord, StringLiteral LeftKeyName, typename ThroughRecord, StringLiteral RightKeyName>
+bool HasManyThrough<TargetRecord, LeftKeyName, ThroughRecord, RightKeyName>::IsEmpty() const noexcept
+{
+    return Count() == 0;
+}
+
+template <typename TargetRecord, StringLiteral LeftKeyName, typename ThroughRecord, StringLiteral RightKeyName>
+size_t HasManyThrough<TargetRecord, LeftKeyName, ThroughRecord, RightKeyName>::Count() const
+{
+    if (IsLoaded())
+        return m_models.size();
+
+    auto const targetRecord = TargetRecord();
+    auto const throughRecordMeta = ThroughRecord(); // TODO: eliminate instances, allowing direct access to meta info
+
+    return TargetRecord::Join(throughRecordMeta.TableName(),
+                              LeftKeyName.value,
+                              SqlQualifiedTableColumnName(targetRecord.TableName(), targetRecord.PrimaryKeyName()))
+        .Join(m_record->TableName(),
+              m_record->PrimaryKeyName(),
+              SqlQualifiedTableColumnName(throughRecordMeta.TableName(), RightKeyName.value))
+        .Where(SqlQualifiedTableColumnName(m_record->TableName(), m_record->PrimaryKeyName()), m_record->Id())
+        .Count();
+}
+
+template <typename TargetRecord, StringLiteral LeftKeyName, typename ThroughRecord, StringLiteral RightKeyName>
+inline std::vector<TargetRecord>& HasManyThrough<TargetRecord, LeftKeyName, ThroughRecord, RightKeyName>::All()
+{
+    RequireLoaded();
+    return m_models;
+}
+
+template <typename TargetRecord, StringLiteral LeftKeyName, typename ThroughRecord, StringLiteral RightKeyName>
+TargetRecord& HasManyThrough<TargetRecord, LeftKeyName, ThroughRecord, RightKeyName>::At(size_t index)
+{
+    RequireLoaded();
+    return m_models.at(index);
+}
+
+template <typename TargetRecord, StringLiteral LeftKeyName, typename ThroughRecord, StringLiteral RightKeyName>
+TargetRecord const& HasManyThrough<TargetRecord, LeftKeyName, ThroughRecord, RightKeyName>::At(size_t index) const
+{
+    RequireLoaded();
+    return m_models.at(index);
+}
+
+template <typename TargetRecord, StringLiteral LeftKeyName, typename ThroughRecord, StringLiteral RightKeyName>
+TargetRecord& HasManyThrough<TargetRecord, LeftKeyName, ThroughRecord, RightKeyName>::operator[](size_t index)
+{
+    RequireLoaded();
+    return m_models[index];
+}
+
+template <typename TargetRecord, StringLiteral LeftKeyName, typename ThroughRecord, StringLiteral RightKeyName>
+TargetRecord const& HasManyThrough<TargetRecord, LeftKeyName, ThroughRecord, RightKeyName>::operator[](
+    size_t index) const
+{
+    RequireLoaded();
+    return m_models[index];
+}
+
+template <typename TargetRecord, StringLiteral LeftKeyName, typename ThroughRecord, StringLiteral RightKeyName>
+template <typename Callback>
+inline void HasManyThrough<TargetRecord, LeftKeyName, ThroughRecord, RightKeyName>::Each(Callback&& callback)
+{
+    if (IsLoaded())
+    {
+        for (auto& model: m_models)
+            callback(model);
+    }
+    else
+    {
+        auto const targetRecord = TargetRecord();
+        auto const throughRecordMeta = ThroughRecord();
+
+        TargetRecord::Join(throughRecordMeta.TableName(),
+                           LeftKeyName.value,
+                           SqlQualifiedTableColumnName(targetRecord.TableName(), targetRecord.PrimaryKeyName()))
+            .Join(m_record->TableName(),
+                  m_record->PrimaryKeyName(),
+                  SqlQualifiedTableColumnName(throughRecordMeta.TableName(), RightKeyName.value))
+            .Where(SqlQualifiedTableColumnName(m_record->TableName(), m_record->PrimaryKeyName()), m_record->Id())
+            .Each(callback);
+    }
+}
+
+template <typename TargetRecord, StringLiteral LeftKeyName, typename ThroughRecord, StringLiteral RightKeyName>
+inline bool HasManyThrough<TargetRecord, LeftKeyName, ThroughRecord, RightKeyName>::IsLoaded() const noexcept
+{
+    return m_loaded;
+}
+
+template <typename TargetRecord, StringLiteral LeftKeyName, typename ThroughRecord, StringLiteral RightKeyName>
+void HasManyThrough<TargetRecord, LeftKeyName, ThroughRecord, RightKeyName>::Load()
+{
+    if (m_loaded)
+        return;
+
+    auto const targetRecord = TargetRecord();
+    auto const throughRecordMeta = ThroughRecord();
+
+    m_models =
+        TargetRecord::Join(throughRecordMeta.TableName(),
+                           LeftKeyName.value,
+                           SqlQualifiedTableColumnName(targetRecord.TableName(), targetRecord.PrimaryKeyName()))
+            .Join(m_record->TableName(),
+                  m_record->PrimaryKeyName(),
+                  SqlQualifiedTableColumnName(throughRecordMeta.TableName(), RightKeyName.value))
+            .Where(SqlQualifiedTableColumnName(m_record->TableName(), m_record->PrimaryKeyName()), m_record->Id())
+            .All();
+
+    m_loaded = true;
+}
+
+template <typename TargetRecord, StringLiteral LeftKeyName, typename ThroughRecord, StringLiteral RightKeyName>
+void HasManyThrough<TargetRecord, LeftKeyName, ThroughRecord, RightKeyName>::Reload()
+{
+    m_loaded = false;
+    m_models.clear();
+    Load();
+}
+
+template <typename TargetRecord, StringLiteral LeftKeyName, typename ThroughRecord, StringLiteral RightKeyName>
+void HasManyThrough<TargetRecord, LeftKeyName, ThroughRecord, RightKeyName>::RequireLoaded() const
+{
+    if (!IsLoaded())
+        const_cast<HasManyThrough*>(this)->Load();
+}
+
+// }}}
+
+} // namespace Model

--- a/src/Lightweight/DataMapper/Associations/HasOne.hpp
+++ b/src/Lightweight/DataMapper/Associations/HasOne.hpp
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "../../SqlError.hpp"
+#include "../AbstractRecord.hpp"
+#include "../StringLiteral.hpp"
+
+#include <memory>
+
+namespace Model
+{
+
+// Represents a column in a another table that refers to this record.
+template <typename OtherRecord, StringLiteral TheForeignKeyName>
+class HasOne final
+{
+  public:
+    explicit HasOne(AbstractRecord& record);
+    explicit HasOne(AbstractRecord& record, HasOne&& other);
+
+    OtherRecord& operator*();
+    OtherRecord* operator->();
+    [[nodiscard]] bool IsLoaded() const;
+
+    bool Load();
+    void Reload();
+
+  private:
+    void RequireLoaded();
+
+    AbstractRecord* m_record;
+    std::shared_ptr<OtherRecord> m_otherRecord;
+
+    // We decided to use shared_ptr here, because we do not want to require to know the size of the OtherRecord
+    // at declaration time.
+};
+
+// {{{ HasOne<> implementation
+
+template <typename OtherRecord, StringLiteral TheForeignKeyName>
+HasOne<OtherRecord, TheForeignKeyName>::HasOne(AbstractRecord& record):
+    m_record { &record }
+{
+}
+
+template <typename OtherRecord, StringLiteral TheForeignKeyName>
+HasOne<OtherRecord, TheForeignKeyName>::HasOne(AbstractRecord& record, HasOne&& other):
+    m_record { &record },
+    m_otherRecord { std::move(other.m_otherRecord) }
+{
+}
+
+template <typename OtherRecord, StringLiteral TheForeignKeyName>
+OtherRecord& HasOne<OtherRecord, TheForeignKeyName>::operator*()
+{
+    RequireLoaded();
+    return *m_otherRecord;
+}
+
+template <typename OtherRecord, StringLiteral TheForeignKeyName>
+OtherRecord* HasOne<OtherRecord, TheForeignKeyName>::operator->()
+{
+    RequireLoaded();
+    return &*m_otherRecord;
+}
+
+template <typename OtherRecord, StringLiteral TheForeignKeyName>
+bool HasOne<OtherRecord, TheForeignKeyName>::IsLoaded() const
+{
+    return m_otherRecord.get() != nullptr;
+}
+
+template <typename OtherRecord, StringLiteral TheForeignKeyName>
+bool HasOne<OtherRecord, TheForeignKeyName>::Load()
+{
+    if (m_otherRecord)
+        return true;
+
+    auto foundRecord = OtherRecord::FindBy(TheForeignKeyName.value, m_record->Id());
+    if (!foundRecord)
+        return false;
+
+    m_otherRecord = std::make_shared<OtherRecord>(std::move(foundRecord.value()));
+    return true;
+}
+
+template <typename OtherRecord, StringLiteral TheForeignKeyName>
+void HasOne<OtherRecord, TheForeignKeyName>::Reload()
+{
+    m_otherRecord.reset();
+    Load();
+}
+
+template <typename OtherRecord, StringLiteral TheForeignKeyName>
+void HasOne<OtherRecord, TheForeignKeyName>::RequireLoaded()
+{
+    if (!m_otherRecord)
+        Load();
+}
+
+// }}}
+
+} // namespace Model

--- a/src/Lightweight/DataMapper/Associations/HasOneThrough.hpp
+++ b/src/Lightweight/DataMapper/Associations/HasOneThrough.hpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "../../SqlComposedQuery.hpp"
+#include "../AbstractRecord.hpp"
+#include "../StringLiteral.hpp"
+
+#include <memory>
+
+namespace Model
+{
+
+template <typename OtherRecord, StringLiteral ForeignKeyName, typename ThroughRecord>
+class HasOneThrough
+{
+  public:
+    explicit HasOneThrough(AbstractRecord& record);
+    HasOneThrough(AbstractRecord& record, HasOneThrough&& other) noexcept;
+
+    OtherRecord& operator*();
+    OtherRecord* operator->();
+
+    [[nodiscard]] bool IsLoaded() const noexcept;
+    void Load();
+    void Reload();
+
+  private:
+    AbstractRecord* m_record;
+    std::shared_ptr<OtherRecord> m_otherRecord;
+};
+
+// {{{ inlines
+
+template <typename OtherRecord, StringLiteral ForeignKeyName, typename ThroughRecord>
+HasOneThrough<OtherRecord, ForeignKeyName, ThroughRecord>::HasOneThrough(AbstractRecord& record):
+    m_record { &record }
+{
+}
+
+template <typename OtherRecord, StringLiteral ForeignKeyName, typename ThroughRecord>
+HasOneThrough<OtherRecord, ForeignKeyName, ThroughRecord>::HasOneThrough(AbstractRecord& record,
+                                                                         HasOneThrough&& other) noexcept:
+    m_record { &record },
+    m_otherRecord { std::move(other.m_otherRecord) }
+{
+}
+
+template <typename OtherRecord, StringLiteral ForeignKeyName, typename ThroughRecord>
+OtherRecord& HasOneThrough<OtherRecord, ForeignKeyName, ThroughRecord>::operator*()
+{
+    if (!m_otherRecord)
+        Load();
+
+    return *m_otherRecord;
+}
+
+template <typename OtherRecord, StringLiteral ForeignKeyName, typename ThroughRecord>
+OtherRecord* HasOneThrough<OtherRecord, ForeignKeyName, ThroughRecord>::operator->()
+{
+    if (!m_otherRecord)
+        Load();
+
+    return &*m_otherRecord;
+}
+
+template <typename OtherRecord, StringLiteral ForeignKeyName, typename ThroughRecord>
+bool HasOneThrough<OtherRecord, ForeignKeyName, ThroughRecord>::IsLoaded() const noexcept
+{
+    return m_otherRecord.get();
+}
+
+template <typename OtherRecord, StringLiteral ForeignKeyName, typename ThroughRecord>
+void HasOneThrough<OtherRecord, ForeignKeyName, ThroughRecord>::Load()
+{
+    if (IsLoaded())
+        return;
+
+    auto result =
+        OtherRecord::template Join<ThroughRecord, ForeignKeyName>()
+            .Where(SqlQualifiedTableColumnName(OtherRecord().TableName(), ForeignKeyName.value), m_record->Id().value)
+            .First();
+
+    if (!result.has_value())
+    {
+        SqlLogger::GetLogger().OnWarning(std::format("No data found on table {} for {} = {}",
+                                                     OtherRecord().TableName(),
+                                                     ForeignKeyName.value,
+                                                     m_record->Id().value));
+        return;
+    }
+
+    m_otherRecord = std::make_shared<OtherRecord>(std::move(result.value()));
+}
+
+template <typename OtherRecord, StringLiteral ForeignKeyName, typename ThroughRecord>
+void HasOneThrough<OtherRecord, ForeignKeyName, ThroughRecord>::Reload()
+{
+    m_otherRecord.reset();
+    return Load();
+}
+
+// }}}
+
+} // namespace Model

--- a/src/Lightweight/DataMapper/BelongsTo.hpp
+++ b/src/Lightweight/DataMapper/BelongsTo.hpp
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "../DataBinder/Core.hpp"
+#include "../DataBinder/SqlNullValue.hpp"
+#include "../SqlStatement.hpp"
+#include "../Utils.hpp"
+#include "Error.hpp"
+#include "Field.hpp"
+
+#include <compare>
+#include <type_traits>
+
+// Represents a one-to-one relationship.
+//
+// The `TheReferencedField` parameter is the field in the other record that references the current record.
+template <auto TheReferencedField>
+class BelongsTo
+{
+  public:
+    static constexpr auto ReferencedField = TheReferencedField;
+
+    // Represents the record type of the other field.
+    using ReferencedRecord = MemberClassType<decltype(TheReferencedField)>;
+
+    // Represents the column type of the foreign key, matching the primary key of the other record.
+    using ValueType =
+        typename std::remove_cvref_t<decltype(std::declval<ReferencedRecord>().*ReferencedField)>::ValueType;
+
+    static constexpr auto IsOptional = true;
+    static constexpr auto IsMandatory = !IsOptional;
+    static constexpr auto IsPrimaryKey = false;
+    static constexpr auto IsAutoIncrementPrimaryKey = false;
+
+    template <typename... S>
+        requires std::constructible_from<ValueType, S...>
+    constexpr BelongsTo(S&&... value) noexcept:
+        _referencedFieldValue(std::forward<S>(value)...)
+    {
+    }
+
+    constexpr BelongsTo(ReferencedRecord const& other) noexcept:
+        _referencedFieldValue { (other.*ReferencedField).Value() },
+        _loaded { true },
+        _record { other }
+    {
+    }
+
+    BelongsTo& operator=(SqlNullType /*nullValue*/) noexcept
+    {
+        if (!_referencedFieldValue)
+            return *this;
+        _loaded = false;
+        _record = std::nullopt;
+        _referencedFieldValue = {};
+        _modified = true;
+        return *this;
+    }
+
+    BelongsTo& operator=(ReferencedRecord& other)
+    {
+        if (_referencedFieldValue == (other.*ReferencedField).Value())
+            return *this;
+        _loaded = true;
+        _record.emplace(other);
+        _referencedFieldValue = (other.*ReferencedField).Value();
+        _modified = true;
+        return *this;
+    }
+
+    // clang-format off
+    LIGHTWEIGHT_FORCE_INLINE constexpr void SetModified(bool value) noexcept { _modified = value; }
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr bool IsModified() const noexcept { return _modified; }
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ValueType const& Value() const noexcept { return _referencedFieldValue; }
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ValueType& MutableValue() noexcept { return _referencedFieldValue; }
+    LIGHTWEIGHT_FORCE_INLINE void BindOutputColumn(SQLSMALLINT outputIndex, SqlStatement& stmt) { stmt.BindOutputColumn(outputIndex, &_referencedFieldValue); }
+
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord& EmplaceRecord() { _loaded = true; return _record.emplace(); }
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord& Record() noexcept { RequireLoaded(); return _record.value(); }
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord const& Record() const noexcept { RequireLoaded(); return _record.value(); }
+
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr bool IsLoaded() const noexcept { return _loaded; }
+    LIGHTWEIGHT_FORCE_INLINE void Unload() noexcept { _record = std::nullopt; _loaded = false; }
+
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord& operator*() noexcept { RequireLoaded(); return _record.value(); }
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord const& operator*() const noexcept { RequireLoaded(); return _record.value(); }
+
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord* operator->() noexcept { RequireLoaded(); return &_record.value(); }
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord const* operator->() const noexcept { RequireLoaded(); return &_record.value(); }
+
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr bool operator!() const noexcept { return !_referencedFieldValue; }
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr explicit operator bool() const noexcept { return static_cast<bool>(_referencedFieldValue); }
+    // clang-format on
+
+    template <auto OtherReferencedField>
+    std::weak_ordering operator<=>(BelongsTo<OtherReferencedField> const& other) const noexcept
+    {
+        return _referencedFieldValue <=> other.Value();
+    }
+
+    template <detail::FieldElementType T, PrimaryKey IsPrimaryKeyValue = PrimaryKey::No>
+    std::weak_ordering operator<=>(Field<T, IsPrimaryKeyValue> const& other) const noexcept
+    {
+        return _referencedFieldValue <=> other.Value();
+    }
+
+    template <auto OtherReferencedField>
+    bool operator==(BelongsTo<OtherReferencedField> const& other) const noexcept
+    {
+        return (_referencedFieldValue <=> other.Value()) == std::weak_ordering::equivalent;
+    }
+
+    template <auto OtherReferencedField>
+    bool operator!=(BelongsTo<OtherReferencedField> const& other) const noexcept
+    {
+        return (_referencedFieldValue <=> other.Value()) != std::weak_ordering::equivalent;
+    }
+
+    template <detail::FieldElementType T, PrimaryKey IsPrimaryKeyValue = PrimaryKey::No>
+    bool operator==(Field<T, IsPrimaryKeyValue> const& other) const noexcept
+    {
+        return (_referencedFieldValue <=> other.Value()) == std::weak_ordering::equivalent;
+    }
+
+    template <detail::FieldElementType T, PrimaryKey IsPrimaryKeyValue = PrimaryKey::No>
+    bool operator!=(Field<T, IsPrimaryKeyValue> const& other) const noexcept
+    {
+        return (_referencedFieldValue <=> other.Value()) != std::weak_ordering::equivalent;
+    }
+
+    struct Loader
+    {
+        std::function<void()> loadReference {};
+    };
+
+    void SetAutoLoader(Loader loader) noexcept
+    {
+        _loader = std::move(loader);
+    }
+
+  private:
+    void RequireLoaded()
+    {
+        if (_loaded)
+            return;
+
+        _loader.loadReference();
+
+        if (!_loaded)
+            throw SqlRequireLoadedError(Reflection::TypeName<std::remove_cvref_t<decltype(*this)>>);
+    }
+
+    ValueType _referencedFieldValue {};
+    Loader _loader {};
+    bool _loaded = false;
+    bool _modified = false;
+    std::optional<ReferencedRecord> _record {};
+};
+
+template <auto ReferencedField>
+std::ostream& operator<<(std::ostream& os, BelongsTo<ReferencedField> const& belongsTo)
+{
+    return os << belongsTo.Value();
+}
+
+namespace detail
+{
+template <typename T>
+struct IsBelongsTo: std::false_type
+{
+};
+
+template <auto ReferencedField>
+struct IsBelongsTo<BelongsTo<ReferencedField>>: std::true_type
+{
+};
+} // namespace detail
+
+template <typename T>
+constexpr bool IsBelongsTo = detail::IsBelongsTo<std::remove_cvref_t<T>>::value;
+
+template <auto ReferencedField>
+struct SqlDataBinder<BelongsTo<ReferencedField>>
+{
+    using SelfType = BelongsTo<ReferencedField>;
+    using InnerType = typename SelfType::ValueType;
+
+    static constexpr auto ColumnType = SqlDataBinder<InnerType>::ColumnType;
+
+    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN InputParameter(SQLHSTMT stmt,
+                                                             SQLUSMALLINT column,
+                                                             SelfType const& value,
+                                                             SqlDataBinderCallback& cb)
+    {
+        return SqlDataBinder<InnerType>::InputParameter(stmt, column, value.Value(), cb);
+    }
+
+    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN
+    OutputColumn(SQLHSTMT stmt, SQLUSMALLINT column, SelfType* result, SQLLEN* indicator, SqlDataBinderCallback& cb)
+    {
+        auto const sqlReturn =
+            SqlDataBinder<InnerType>::OutputColumn(stmt, column, &result->MutableValue(), indicator, cb);
+        cb.PlanPostProcessOutputColumn([result]() { result->SetModified(true); });
+        return sqlReturn;
+    }
+
+    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN GetColumn(SQLHSTMT stmt,
+                                                        SQLUSMALLINT column,
+                                                        SelfType* result,
+                                                        SQLLEN* indicator,
+                                                        SqlDataBinderCallback const& cb) noexcept
+    {
+        auto const sqlReturn = SqlDataBinder<InnerType>::GetColumn(stmt, column, &result->emplace(), indicator, cb);
+        if (SQL_SUCCEEDED(sqlReturn))
+            result->SetModified(true);
+        return sqlReturn;
+    }
+};

--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -1,0 +1,988 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "../SqlConnection.hpp"
+#include "../SqlDataBinder.hpp"
+#include "../SqlStatement.hpp"
+#include "BelongsTo.hpp"
+#include "Detail.hpp"
+#include "Field.hpp"
+#include "HasMany.hpp"
+#include "HasManyThrough.hpp"
+#include "HasOneThrough.hpp"
+#include "Logger.hpp"
+#include "RecordId.hpp"
+
+#include <reflection-cpp/reflection.hpp>
+
+#include <cassert>
+#include <concepts>
+#include <type_traits>
+
+// Requires that T satisfies to be a field with storage.
+template <typename T>
+concept FieldWithStorage = requires(T const& field, T& mutableField) {
+    { field.Value() } -> std::convertible_to<typename T::ValueType const&>;
+    { mutableField.MutableValue() } -> std::convertible_to<typename T::ValueType&>;
+    { field.IsModified() } -> std::convertible_to<bool>;
+    { mutableField.SetModified(bool {}) } -> std::convertible_to<void>;
+    { mutableField.BindOutputColumn(SQLSMALLINT {}, std::declval<SqlStatement&>()) } -> std::convertible_to<void>;
+};
+
+// Represents the number of fields with storage in a record.
+template <typename Record>
+constexpr size_t RecordStorageFieldCount =
+    Reflection::FoldMembers<Record>(size_t { 0 }, []<size_t I, typename Field>(size_t const accum) constexpr {
+        if constexpr (FieldWithStorage<Field>)
+            return accum + 1;
+        else
+            return accum;
+    });
+
+template <typename Record>
+concept RecordWithStorageFields = (RecordStorageFieldCount<Record> > 0);
+
+namespace detail
+{
+
+template <template <typename> class Allocator, template <typename, typename> class Container, typename Object>
+auto ToSharedPtrList(Container<Object, Allocator<Object>> container)
+{
+    using SharedPtrRecord = std::shared_ptr<Object>;
+    auto sharedPtrContainer = Container<SharedPtrRecord, Allocator<SharedPtrRecord>> {};
+    for (auto& object: container)
+        sharedPtrContainer.emplace_back(std::make_shared<Object>(std::move(object)));
+    return sharedPtrContainer;
+}
+
+template <typename Record>
+struct RecordTableName
+{
+    static constexpr std::string_view Value = []() {
+        if constexpr (requires { Record::TableName; })
+            return Record::TableName;
+        else
+            // TODO: Build plural
+            return Reflection::TypeName<Record>;
+    }();
+};
+
+} // namespace detail
+
+template <typename Record>
+constexpr std::string_view RecordTableName = detail::RecordTableName<Record>::Value;
+
+class DataMapper
+{
+  public:
+    DataMapper():
+        _connection {},
+        _stmt { _connection }
+    {
+    }
+
+    explicit DataMapper(SqlConnection&& connection):
+        _connection { std::move(connection) },
+        _stmt { _connection }
+    {
+    }
+
+    DataMapper(DataMapper const&) = delete;
+    DataMapper(DataMapper&&) noexcept = default;
+    DataMapper& operator=(DataMapper const&) = delete;
+    DataMapper& operator=(DataMapper&&) noexcept = default;
+    ~DataMapper() = default;
+
+    [[nodiscard]] SqlConnection const& Connection() const noexcept
+    {
+        return _connection;
+    }
+
+    [[nodiscard]] SqlConnection& Connection() noexcept
+    {
+        return _connection;
+    }
+
+    template <typename Record>
+    static std::string Inspect(Record const& record);
+
+    template <typename Record>
+    std::string CreateTableString(SqlServerType serverType);
+
+    template <typename FirstRecord, typename... MoreRecords>
+    std::string CreateTablesString(SqlServerType serverType);
+
+    // Creates the table for the given record type.
+    template <typename Record>
+    void CreateTable();
+
+    template <typename FirstRecord, typename... MoreRecords>
+    void CreateTables();
+
+    // Creates a new record in the database.
+    //
+    // The record is inserted into the database and the primary key is set on this record.
+    //
+    // @return The primary key of the newly created record.
+    template <typename Record>
+    RecordId Create(Record& record);
+
+    // Creates a new record in the database.
+    //
+    // @note This is a variation of the Create() method and does not update the record's primary key.
+    //
+    // @return The primary key of the newly created record.
+    template <typename Record>
+    RecordId CreateExplicit(Record const& record);
+
+    template <typename Record, typename... Args>
+    std::optional<Record> QuerySingle(SqlSelectQueryBuilder selectQuery, Args&&... args);
+
+    // Queries a single record (based on primary key) from the database.
+    //
+    // The primary key(s) are used to identify the record to load.
+    // If the record is not found, std::nullopt is returned.
+    template <typename Record, typename... PrimaryKeyTypes>
+    std::optional<Record> QuerySingle(PrimaryKeyTypes&&... primaryKeys);
+
+    // Queries multiple records from the database, based on the given query.
+    template <typename Record, typename... InputParameters>
+    std::vector<Record> Query(SqlSelectQueryBuilder::ComposedQuery const& selectQuery,
+                              InputParameters&&... inputParameters);
+
+    // Queries multiple records from the database, based on the given query.
+    template <typename Record, typename... InputParameters>
+    std::vector<Record> Query(std::string_view sqlQueryString, InputParameters&&... inputParameters);
+
+    template <typename Record>
+    bool IsModified(Record const& record) const noexcept;
+
+    template <typename Record>
+    void Update(Record& record);
+
+    template <typename Record>
+    std::size_t Delete(Record const& record);
+
+    template <typename Record>
+    std::size_t Count();
+
+    template <typename Record>
+    std::vector<Record> All();
+
+    template <typename Record>
+    std::optional<Record> Find(RecordId id);
+
+    template <typename Record, typename ColumnName, typename T>
+    std::optional<Record> FindBy(ColumnName const& columnName, T const& value);
+
+    template <typename Record>
+    auto Query() -> SqlQueryBuilder
+    {
+        return _connection.Query(RecordTableName<Record>);
+    }
+
+    template <typename Record>
+    void ClearModifiedState(Record& record) noexcept;
+
+    // Loads the direct relations to this record.
+    template <typename Record>
+    void LoadRelations(Record& record);
+
+    template <typename Record>
+    decltype(auto) GetPrimaryKeyField(Record const& record) const;
+
+    template <typename Record>
+    void ConfigureRelationAutoLoading(Record& record);
+
+  private:
+    template <typename Record, typename ValueType>
+    void SetId(Record& record, ValueType&& id);
+
+    template <typename Record>
+    void BindOutputColumns(Record& record);
+
+    template <typename Record>
+    void BindOutputColumns(Record& record, SqlStatement* stmt);
+
+    template <size_t FieldIndex, auto ReferencedRecordField, typename Record>
+    void LoadBelongsTo(Record& record, BelongsTo<ReferencedRecordField>& field);
+
+    template <size_t FieldIndex, typename Record, typename OtherRecord>
+    void LoadHasMany(Record& record, HasMany<OtherRecord>& field);
+
+    template <typename ReferencedRecord, typename ThroughRecord, typename Record>
+    void LoadHasOneThrough(Record& record, HasOneThrough<ReferencedRecord, ThroughRecord>& field);
+
+    template <typename ReferencedRecord, typename ThroughRecord, typename Record>
+    void LoadHasManyThrough(Record& record, HasManyThrough<ReferencedRecord, ThroughRecord>& field);
+
+    template <size_t FieldIndex, typename Record, typename OtherRecord, typename Callable>
+    void CallOnHasMany(Record& record, Callable const& callback);
+
+    template <typename ReferencedRecord, typename ThroughRecord, typename Record, typename Callable>
+    void CallOnHasManyThrough(Record& record, Callable const& callback);
+
+    SqlConnection _connection;
+    SqlStatement _stmt;
+};
+
+// ------------------------------------------------------------------------------------------------
+
+template <typename Record>
+std::string DataMapper::Inspect(Record const& record)
+{
+    std::string str;
+    Reflection::CallOnMembers(record, [&str]<typename Name, typename Value>(Name const& name, Value const& value) {
+        if (!str.empty())
+            str += '\n';
+
+        if constexpr (FieldWithStorage<Value>)
+            str += std::format("{} {} := {}", Reflection::TypeName<Value>, name, value.Value());
+    });
+    return str;
+}
+
+// Returns the SQL field name of the given field index in the record.
+template <auto I, typename Record>
+constexpr std::string_view FieldNameOf()
+{
+    using FieldType = Reflection::MemberTypeOf<I, Record>;
+    if constexpr (IsBelongsTo<FieldType>)
+    {
+        auto constexpr baseName = Reflection::MemberNameOf<I, Record>;
+        static std::array<char, baseName.size() + 3> storage;
+        std::copy_n(baseName.begin(), baseName.size(), storage.begin());
+        std::copy_n("_id", 3, storage.begin() + baseName.size());
+        return { storage.data(), storage.size() };
+    }
+    else
+        return Reflection::MemberNameOf<I, Record>;
+};
+
+template <typename Record>
+std::string DataMapper::CreateTableString(SqlServerType serverType)
+{
+    SqlTraits const& traits = GetSqlTraits(serverType);
+
+    std::vector<std::string> columnsSql;
+    columnsSql.reserve(Reflection::CountMembers<Record>);
+
+    Reflection::EnumerateMembers<Record>([&]<size_t I, typename FieldType>() {
+        if constexpr (FieldWithStorage<FieldType>)
+        {
+            std::stringstream sql;
+            sql << '"' << FieldNameOf<I, Record>() << '"';
+
+            if constexpr (IsAutoIncrementPrimaryKey<FieldType>)
+            {
+                sql << " " << traits.PrimaryKeyAutoIncrement;
+            }
+            else
+            {
+                using FieldBinder = SqlDataBinder<typename FieldType::ValueType>;
+                sql << " " << traits.ColumnTypeName(FieldBinder::ColumnType);
+
+                if constexpr (requires { FieldBinder::ColumnSize; })
+                    sql << "(" << FieldBinder::ColumnSize << ")";
+
+                if constexpr (FieldType::IsMandatory)
+                    sql << " NOT NULL";
+                else
+                    sql << " NULL";
+
+                if constexpr (FieldType::IsPrimaryKey)
+                    sql << " PRIMARY KEY";
+
+                // TODO: properly encode default values to CREATE TABLE statement
+                // This currently always adds quoting, which is wrong.
+                // auto const sqlDefaultValue = Reflection::GetMemberAt<I>(Record {});
+                // SqlQueryFormatter const& formatter = *SqlQueryFormatter::Get(serverType);
+                // constexpr bool isString =
+                //     detail::OneOf<ValueType, SqlTrimmedString, std::string, std::string_view>
+                //     || IsSqlFixedString<ValueType>;
+                // if (sqlDefaultValue.Value() != ValueType {})
+                // {
+                //     if constexpr (isString)
+                //         sql << " DEFAULT " << formatter.StringLiteral(sqlDefaultValue.Value());
+                //     else
+                //         sql << " DEFAULT " << sqlDefaultValue;
+                // }
+            }
+
+            columnsSql.emplace_back(sql.str());
+        }
+    });
+
+    detail::StringBuilder sql;
+    sql << "CREATE TABLE \"" << RecordTableName<Record> << "\" (\n";
+
+    for (auto const&& [i, columnSql]: columnsSql | std::views::enumerate)
+    {
+        sql << "    ";
+        sql << columnSql;
+        if (static_cast<size_t>(i + 1) < columnsSql.size())
+            sql << ",";
+        sql << '\n';
+    }
+
+    sql << ");\n";
+
+    return sql.output;
+}
+
+template <typename FirstRecord, typename... MoreRecords>
+std::string DataMapper::CreateTablesString(SqlServerType serverType)
+{
+    detail::StringBuilder sql;
+    sql << CreateTableString<FirstRecord>(serverType) << (CreateTableString<MoreRecords>(serverType) << ...);
+    return sql.output;
+}
+
+template <typename Record>
+void DataMapper::CreateTable()
+{
+    auto const sqlQueryString = CreateTableString<Record>(_connection.ServerType());
+    auto const scopedModelSqlLogger = detail::SqlScopedModelQueryLogger(sqlQueryString, {});
+    _stmt.ExecuteDirect(sqlQueryString);
+}
+
+template <typename FirstRecord, typename... MoreRecords>
+void DataMapper::CreateTables()
+{
+    CreateTable<FirstRecord>();
+    (CreateTable<MoreRecords>(), ...);
+}
+
+template <typename T>
+constexpr bool HasAutoIncrementPrimaryKey =
+    Reflection::FoldMembers<T>(false, []<size_t I, typename Field>(bool const accum) {
+        if constexpr (FieldWithStorage<Field> && IsAutoIncrementPrimaryKey<Field>)
+            return true;
+        else
+            return accum;
+    });
+
+template <typename Record>
+RecordId DataMapper::CreateExplicit(Record const& record)
+{
+    auto query = _connection.Query(RecordTableName<Record>).Insert(nullptr);
+
+    Reflection::EnumerateMembers(record, [&query]<auto I, typename FieldType>(FieldType const& /*field*/) {
+        if constexpr (FieldWithStorage<FieldType> && !IsAutoIncrementPrimaryKey<FieldType>)
+            query.Set(FieldNameOf<I, Record>(), SqlWildcard);
+    });
+
+    _stmt.Prepare(query);
+
+    Reflection::CallOnMembers(record,
+                              [this, i = SQLSMALLINT { 1 }]<typename Name, typename FieldType>(
+                                  Name const& /*name*/, FieldType const& field) mutable {
+                                  if constexpr (FieldWithStorage<FieldType> && !IsAutoIncrementPrimaryKey<FieldType>)
+                                      _stmt.BindInputParameter(i++, field.Value());
+                              });
+
+    _stmt.Execute();
+
+    if constexpr (HasAutoIncrementPrimaryKey<Record>)
+        return { _stmt.LastInsertId() };
+    else
+        return {};
+}
+
+template <typename Record>
+RecordId DataMapper::Create(Record& record)
+{
+    static_assert(!std::is_const_v<Record>);
+
+    // If the primary key is not an auto-increment field and the primary key is not set, we need to set it.
+    CallOnPrimaryKey(record, [&]<size_t PrimaryKeyIndex, typename PrimaryKeyType>(PrimaryKeyType& primaryKeyField) {
+        if constexpr (!PrimaryKeyType::IsAutoIncrementPrimaryKey)
+        {
+            using ValueType = typename PrimaryKeyType::ValueType;
+            if (primaryKeyField.Value() == ValueType {})
+            {
+                auto maxId = SqlStatement { _connection }.ExecuteDirectSingle<ValueType>(
+                    std::format(R"sql(SELECT MAX("{}") FROM "{}")sql",
+                                FieldNameOf<PrimaryKeyIndex, Record>(),
+                                RecordTableName<Record>));
+                primaryKeyField = maxId.value_or(ValueType {}) + 1;
+            }
+        }
+    });
+
+    auto const id = CreateExplicit(record);
+
+    if constexpr (HasAutoIncrementPrimaryKey<Record>)
+        SetId(record, id.value);
+
+    ClearModifiedState(record);
+    ConfigureRelationAutoLoading(record);
+
+    return id;
+}
+
+template <typename Record>
+bool DataMapper::IsModified(Record const& record) const noexcept
+{
+    bool modified = false;
+
+    Reflection::CallOnMembers(record, [&modified](auto const& /*name*/, auto const& field) {
+        if constexpr (requires { field.IsModified(); })
+        {
+            modified = modified || field.IsModified();
+        }
+    });
+
+    return modified;
+}
+
+template <typename Record>
+void DataMapper::Update(Record& record)
+{
+    auto query = _connection.Query(RecordTableName<Record>).Update();
+
+    Reflection::CallOnMembers(record,
+                              [&query]<typename Name, typename FieldType>(Name const& name, FieldType const& field) {
+                                  if (field.IsModified())
+                                      query.Set(name, SqlWildcard);
+                                  if constexpr (FieldType::IsPrimaryKey)
+                                      if (!field.IsModified())
+                                          std::ignore = query.Where(name, SqlWildcard);
+                              });
+
+    _stmt.Prepare(query);
+
+    // Bind the SET clause
+    SQLSMALLINT i = 1;
+    Reflection::CallOnMembers(
+        record, [this, &i]<typename Name, typename FieldType>(Name const& /*name*/, FieldType const& field) mutable {
+            if (field.IsModified())
+                _stmt.BindInputParameter(i++, field.Value());
+        });
+
+    // Bind the WHERE clause
+    Reflection::CallOnMembers(
+        record, [this, &i]<typename Name, typename FieldType>(Name const& /*name*/, FieldType const& field) mutable {
+            if constexpr (FieldType::IsPrimaryKey)
+                if (!field.IsModified())
+                    _stmt.BindInputParameter(i++, field.Value());
+        });
+
+    _stmt.Execute();
+
+    ClearModifiedState(record);
+}
+
+template <typename Record>
+std::size_t DataMapper::Delete(Record const& record)
+{
+    auto query = _connection.Query(RecordTableName<Record>).Delete();
+
+    Reflection::CallOnMembers(
+        record, [&query]<typename Name, typename FieldType>(Name const& name, FieldType const& /*field*/) {
+            if constexpr (FieldType::IsPrimaryKey)
+                std::ignore = query.Where(name, SqlWildcard);
+        });
+
+    _stmt.Prepare(query);
+
+    // Bind the WHERE clause
+    Reflection::CallOnMembers(record,
+                              [this, i = SQLSMALLINT { 1 }]<typename Name, typename FieldType>(
+                                  Name const& /*name*/, FieldType const& field) mutable {
+                                  if constexpr (FieldType::IsPrimaryKey)
+                                      _stmt.BindInputParameter(i++, field.Value());
+                              });
+
+    _stmt.Execute();
+
+    return _stmt.NumRowsAffected();
+}
+
+template <typename Record, typename... PrimaryKeyTypes>
+std::optional<Record> DataMapper::QuerySingle(PrimaryKeyTypes&&... primaryKeys)
+{
+    auto queryBuilder = _connection.Query(RecordTableName<Record>).Select();
+
+    Reflection::EnumerateMembers<Record>([&]<size_t I, typename FieldType>() {
+        if constexpr (FieldWithStorage<FieldType>)
+        {
+            queryBuilder.Field(FieldNameOf<I, Record>());
+
+            if constexpr (FieldType::IsPrimaryKey)
+                std::ignore = queryBuilder.Where(FieldNameOf<I, Record>(), SqlWildcard);
+        }
+    });
+
+    _stmt.Prepare(queryBuilder.First());
+    _stmt.Execute(std::forward<PrimaryKeyTypes>(primaryKeys)...);
+
+    auto resultRecord = Record {};
+    BindOutputColumns(resultRecord);
+
+    if (!_stmt.FetchRow())
+        return std::nullopt;
+
+    _stmt.CloseCursor();
+
+    ConfigureRelationAutoLoading(resultRecord);
+
+    return { std::move(resultRecord) };
+}
+
+template <typename Record, typename... Args>
+std::optional<Record> DataMapper::QuerySingle(SqlSelectQueryBuilder selectQuery, Args&&... args)
+{
+    Reflection::EnumerateMembers<Record>([&]<size_t I, typename FieldType>() {
+        if constexpr (FieldWithStorage<FieldType>)
+            selectQuery.Field(SqlQualifiedTableColumnName { RecordTableName<Record>, FieldNameOf<I, Record>() });
+    });
+    _stmt.Prepare(selectQuery.First().ToSql());
+    _stmt.Execute(std::forward<Args>(args)...);
+
+    auto resultRecord = Record {};
+    BindOutputColumns(resultRecord);
+
+    if (!_stmt.FetchRow())
+        return std::nullopt;
+
+    _stmt.CloseCursor();
+
+    ConfigureRelationAutoLoading(resultRecord);
+
+    return { std::move(resultRecord) };
+}
+
+// TODO: Provide Query(QueryBuilder, ...) method variant
+
+template <typename Record, typename... InputParameters>
+inline LIGHTWEIGHT_FORCE_INLINE std::vector<Record> DataMapper::Query(
+    SqlSelectQueryBuilder::ComposedQuery const& selectQuery, InputParameters&&... inputParameters)
+{
+    return Query<Record>(selectQuery.ToSql(), std::forward<InputParameters>(inputParameters)...);
+}
+
+template <typename Record, typename... InputParameters>
+std::vector<Record> DataMapper::Query(std::string_view sqlQueryString, InputParameters&&... inputParameters)
+{
+    _stmt.Prepare(sqlQueryString);
+    _stmt.Execute(std::forward<InputParameters>(inputParameters)...);
+
+    auto result = std::vector<Record> {};
+
+    auto record = Record {};
+    BindOutputColumns(record);
+    ConfigureRelationAutoLoading(record);
+
+    while (_stmt.FetchRow())
+    {
+        result.emplace_back(std::move(record));
+        record = Record {};
+        BindOutputColumns(record);
+        ConfigureRelationAutoLoading(record);
+    }
+
+    return result;
+}
+
+template <typename Record>
+void DataMapper::ClearModifiedState(Record& record) noexcept
+{
+    static_assert(!std::is_const_v<Record>);
+
+    Reflection::EnumerateMembers(record, []<size_t I, typename FieldType>(FieldType& field) {
+        if constexpr (requires { field.SetModified(false); })
+        {
+            field.SetModified(false);
+        }
+    });
+}
+
+template <typename Record, typename Callable>
+inline LIGHTWEIGHT_FORCE_INLINE void CallOnPrimaryKey(Record& record, Callable const& callable)
+{
+    Reflection::EnumerateMembers(record, [&]<size_t I, typename FieldType>(FieldType& field) {
+        if constexpr (IsField<FieldType>)
+        {
+            if constexpr (FieldType::IsPrimaryKey)
+            {
+                return callable.template operator()<I, FieldType>(field);
+            }
+        }
+    });
+}
+
+template <typename Record, typename Callable>
+inline LIGHTWEIGHT_FORCE_INLINE void CallOnPrimaryKey(Callable const& callable)
+{
+    Reflection::EnumerateMembers<Record>([&]<size_t I, typename FieldType>() {
+        if constexpr (IsField<FieldType>)
+        {
+            if constexpr (FieldType::IsPrimaryKey)
+            {
+                return callable.template operator()<I, FieldType>();
+            }
+        }
+    });
+}
+
+template <typename Record, typename Callable>
+inline LIGHTWEIGHT_FORCE_INLINE void CallOnBelongsTo(Callable const& callable)
+{
+    Reflection::EnumerateMembers<Record>([&]<size_t I, typename FieldType>() {
+        if constexpr (IsBelongsTo<FieldType>)
+        {
+            return callable.template operator()<I, FieldType>();
+        }
+    });
+}
+
+template <size_t FieldIndex, auto ReferencedRecordField, typename Record>
+void DataMapper::LoadBelongsTo(Record& record, BelongsTo<ReferencedRecordField>& field)
+{
+    using FieldType = BelongsTo<ReferencedRecordField>;
+    using ReferencedRecord = typename FieldType::ReferencedRecord;
+
+    CallOnPrimaryKey(record,
+                     [&]<size_t PrimaryKeyIndex, typename PrimaryKeyType>(PrimaryKeyType const& primaryKeyField) {
+                         if (auto result = QuerySingle<ReferencedRecord>(primaryKeyField.Value()); result)
+                         {
+                             field.EmplaceRecord() = std::move(*result);
+                         }
+                     });
+}
+
+template <size_t FieldIndex, typename Record, typename OtherRecord, typename Callable>
+void DataMapper::CallOnHasMany(Record& record, Callable const& callback)
+{
+    using FieldType = HasMany<OtherRecord>;
+    using ReferencedRecord = typename FieldType::ReferencedRecord;
+
+    CallOnPrimaryKey(
+        record, [&]<size_t PrimaryKeyIndex, typename PrimaryKeyType>(PrimaryKeyType const& primaryKeyField) {
+            auto query = _connection.Query(RecordTableName<ReferencedRecord>)
+                             .Select()
+                             .Build([&](auto& query) {
+                                 Reflection::EnumerateMembers<ReferencedRecord>(
+                                     [&]<size_t ReferencedFieldIndex, typename ReferencedFieldType>() {
+                                         if constexpr (FieldWithStorage<ReferencedFieldType>)
+                                         {
+                                             query.Field(FieldNameOf<ReferencedFieldIndex, ReferencedRecord>());
+                                         }
+                                     });
+                             })
+                             .Where(FieldNameOf<FieldIndex, ReferencedRecord>(), SqlWildcard);
+            callback(query, primaryKeyField);
+        });
+}
+
+template <size_t FieldIndex, typename Record, typename OtherRecord>
+void DataMapper::LoadHasMany(Record& record, HasMany<OtherRecord>& field)
+{
+    CallOnHasMany<FieldIndex, Record, OtherRecord>(
+        record, [&](SqlSelectQueryBuilder selectQuery, auto& primaryKeyField) {
+            field.Emplace(detail::ToSharedPtrList(Query<OtherRecord>(selectQuery.All(), primaryKeyField.Value())));
+        });
+}
+
+template <typename ReferencedRecord, typename ThroughRecord, typename Record>
+void DataMapper::LoadHasOneThrough(Record& record, HasOneThrough<ReferencedRecord, ThroughRecord>& field)
+{
+    // Find the PK of Record
+    CallOnPrimaryKey(
+        record, [&]<size_t PrimaryKeyIndex, typename PrimaryKeyType>(PrimaryKeyType const& primaryKeyField) {
+            // Find the BelongsTo of ThroughRecord pointing to the PK of Record
+            CallOnBelongsTo<ThroughRecord>([&]<size_t ThroughBelongsToIndex, typename ThroughBelongsToType>() {
+                // Find the PK of ThroughRecord
+                CallOnPrimaryKey<ThroughRecord>([&]<size_t ThroughPrimaryKeyIndex, typename ThroughPrimaryKeyType>() {
+                    // Find the BelongsTo of ReferencedRecord pointing to the PK of ThroughRecord
+                    CallOnBelongsTo<ReferencedRecord>([&]<size_t ReferencedKeyIndex, typename ReferencedKeyType>() {
+                        // Query the ReferencedRecord where:
+                        // - the BelongsTo of ReferencedRecord points to the PK of ThroughRecord,
+                        // - and the BelongsTo of ThroughRecord points to the PK of Record
+                        auto query = _connection.Query(RecordTableName<ReferencedRecord>)
+                                         .Select()
+                                         .Build([&](auto& query) {
+                                             Reflection::EnumerateMembers<ReferencedRecord>(
+                                                 [&]<size_t ReferencedFieldIndex, typename ReferencedFieldType>() {
+                                                     if constexpr (FieldWithStorage<ReferencedFieldType>)
+                                                     {
+                                                         query.Field(SqlQualifiedTableColumnName {
+                                                             RecordTableName<ReferencedRecord>,
+                                                             FieldNameOf<ReferencedFieldIndex, ReferencedRecord>() });
+                                                     }
+                                                 });
+                                         })
+                                         .InnerJoin(RecordTableName<ThroughRecord>,
+                                                    FieldNameOf<ThroughPrimaryKeyIndex, ThroughRecord>(),
+                                                    FieldNameOf<ReferencedKeyIndex, ReferencedRecord>())
+                                         .InnerJoin(RecordTableName<Record>,
+                                                    FieldNameOf<PrimaryKeyIndex, Record>(),
+                                                    SqlQualifiedTableColumnName {
+                                                        RecordTableName<ThroughRecord>,
+                                                        FieldNameOf<ThroughBelongsToIndex, ThroughRecord>() })
+                                         .Where(
+                                             SqlQualifiedTableColumnName {
+                                                 RecordTableName<Record>,
+                                                 FieldNameOf<PrimaryKeyIndex, ThroughRecord>(),
+                                             },
+                                             SqlWildcard);
+                        if (auto link = QuerySingle<ReferencedRecord>(std::move(query), primaryKeyField.Value()); link)
+                        {
+                            field.EmplaceRecord(std::make_shared<ReferencedRecord>(std::move(*link)));
+                        }
+                    });
+                });
+            });
+        });
+}
+
+template <typename ReferencedRecord, typename ThroughRecord, typename Record, typename Callable>
+void DataMapper::CallOnHasManyThrough(Record& record, Callable const& callback)
+{
+    // Find the PK of Record
+    CallOnPrimaryKey(
+        record, [&]<size_t PrimaryKeyIndex, typename PrimaryKeyType>(PrimaryKeyType const& primaryKeyField) {
+            // Find the BelongsTo of ThroughRecord pointing to the PK of Record
+            CallOnBelongsTo<ThroughRecord>(
+                [&]<size_t ThroughBelongsToRecordIndex, typename ThroughBelongsToRecordType>() {
+                    using ThroughBelongsToRecordFieldType =
+                        Reflection::MemberTypeOf<ThroughBelongsToRecordIndex, ThroughRecord>;
+                    if constexpr (std::is_same_v<typename ThroughBelongsToRecordFieldType::ReferencedRecord, Record>)
+                    {
+                        // Find the BelongsTo of ThroughRecord pointing to the PK of ReferencedRecord
+                        CallOnBelongsTo<ThroughRecord>([&]<size_t ThroughBelongsToReferenceRecordIndex,
+                                                           typename ThroughBelongsToReferenceRecordType>() {
+                            using ThroughBelongsToReferenceRecordFieldType =
+                                Reflection::MemberTypeOf<ThroughBelongsToReferenceRecordIndex, ThroughRecord>;
+                            if constexpr (std::is_same_v<
+                                              typename ThroughBelongsToReferenceRecordFieldType::ReferencedRecord,
+                                              ReferencedRecord>)
+                            {
+                                auto query =
+                                    _connection.Query(RecordTableName<ReferencedRecord>)
+                                        .Select()
+                                        .Build([&](auto& query) {
+                                            Reflection::EnumerateMembers<ReferencedRecord>(
+                                                [&]<size_t ReferencedFieldIndex, typename ReferencedFieldType>() {
+                                                    if constexpr (FieldWithStorage<ReferencedFieldType>)
+                                                    {
+                                                        query.Field(SqlQualifiedTableColumnName {
+                                                            RecordTableName<ReferencedRecord>,
+                                                            FieldNameOf<ReferencedFieldIndex, ReferencedRecord>() });
+                                                    }
+                                                });
+                                        })
+                                        .InnerJoin(
+                                            RecordTableName<ThroughRecord>,
+                                            FieldNameOf<ThroughBelongsToReferenceRecordIndex, ThroughRecord>(),
+                                            SqlQualifiedTableColumnName { RecordTableName<ReferencedRecord>,
+                                                                          FieldNameOf<PrimaryKeyIndex, Record>() })
+                                        .Where(
+                                            SqlQualifiedTableColumnName {
+                                                RecordTableName<ThroughRecord>,
+                                                FieldNameOf<ThroughBelongsToRecordIndex, ThroughRecord>(),
+                                            },
+                                            SqlWildcard);
+                                callback(query, primaryKeyField);
+                            }
+                        });
+                    }
+                });
+        });
+}
+
+template <typename ReferencedRecord, typename ThroughRecord, typename Record>
+void DataMapper::LoadHasManyThrough(Record& record, HasManyThrough<ReferencedRecord, ThroughRecord>& field)
+{
+    CallOnHasManyThrough<ReferencedRecord, ThroughRecord>(
+        record, [&](SqlSelectQueryBuilder& selectQuery, auto& primaryKeyField) {
+            field.Emplace(detail::ToSharedPtrList(Query<ReferencedRecord>(selectQuery.All(), primaryKeyField.Value())));
+        });
+}
+
+template <typename Record>
+void DataMapper::LoadRelations(Record& record)
+{
+    static_assert(!std::is_const_v<Record>);
+
+    Reflection::EnumerateMembers<Record>(record, [&]<size_t FieldIndex, typename FieldType>(FieldType& field) {
+        if constexpr (IsBelongsTo<FieldType>)
+        {
+            LoadBelongsTo<FieldIndex>(record, field);
+        }
+        else if constexpr (IsHasMany<FieldType>)
+        {
+            LoadHasMany<FieldIndex>(record, field);
+        }
+        else if constexpr (IsHasOneThrough<FieldType>)
+        {
+            LoadHasOneThrough(record, field);
+        }
+        else if constexpr (IsHasManyThrough<FieldType>)
+        {
+            LoadHasManyThrough(record, field);
+        }
+    });
+}
+
+template <typename Record>
+inline LIGHTWEIGHT_FORCE_INLINE decltype(auto) DataMapper::GetPrimaryKeyField(Record const& record) const
+{
+    Reflection::EnumerateMembers(record, [&]<size_t I, typename FieldType>(FieldType& field) {
+        if constexpr (IsField<FieldType>)
+        {
+            if constexpr (FieldType::IsPrimaryKey)
+            {
+                return field;
+            }
+        }
+    });
+}
+
+template <typename Record, typename ValueType>
+inline LIGHTWEIGHT_FORCE_INLINE void DataMapper::SetId(Record& record, ValueType&& id)
+{
+    // static_assert(HasPrimaryKey<Record>);
+
+    Reflection::EnumerateMembers(record, [&]<size_t I, typename FieldType>(FieldType& field) {
+        if constexpr (IsField<FieldType>)
+        {
+            if constexpr (FieldType::IsPrimaryKey)
+            {
+                field = std::forward<FieldType>(id);
+            }
+        }
+    });
+}
+
+template <typename Record>
+inline LIGHTWEIGHT_FORCE_INLINE void DataMapper::BindOutputColumns(Record& record)
+{
+    BindOutputColumns(record, &_stmt);
+}
+
+template <typename Record>
+void DataMapper::BindOutputColumns(Record& record, SqlStatement* stmt)
+{
+    assert(stmt != nullptr);
+    static_assert(!std::is_const_v<Record>);
+
+    Reflection::EnumerateMembers(record, [this, stmt, i = 1]<size_t I, typename Field>(Field& field) mutable {
+        if constexpr (FieldWithStorage<Field>)
+        {
+            field.BindOutputColumn(i++, *stmt);
+        }
+    });
+}
+
+template <typename Record>
+void DataMapper::ConfigureRelationAutoLoading(Record& record)
+{
+    Reflection::EnumerateMembers(record, [&]<size_t FieldIndex, typename FieldType>(FieldType& field) {
+        if constexpr (IsBelongsTo<FieldType>)
+        {
+            BelongsTo<FieldType::ReferencedField>& belongsTo = field;
+            belongsTo.SetAutoLoader(typename FieldType::Loader {
+                .loadReference = [this, &record, &belongsTo]() { LoadBelongsTo<FieldIndex>(record, belongsTo); },
+            });
+        }
+        else if constexpr (IsHasMany<FieldType>)
+        {
+            using ReferencedRecord = typename FieldType::ReferencedRecord;
+            HasMany<ReferencedRecord>& hasMany = field;
+            hasMany.SetAutoLoader(typename FieldType::Loader {
+                .count = [this, &record, &hasMany]() -> size_t {
+                    size_t count = 0;
+                    CallOnHasMany<FieldIndex, Record, ReferencedRecord>(
+                        record, [&](SqlSelectQueryBuilder selectQuery, auto const& primaryKeyField) {
+                            _stmt.Prepare(selectQuery.Count());
+                            _stmt.Execute(primaryKeyField.Value());
+                            if (_stmt.FetchRow())
+                                count = _stmt.GetColumn<size_t>(1);
+                            _stmt.CloseCursor();
+                        });
+                    return count;
+                },
+                .all = [this, &record, &hasMany]() { LoadHasMany<FieldIndex>(record, hasMany); },
+                .each =
+                    [this, &record, &hasMany](auto const& each) {
+                        CallOnHasMany<FieldIndex, Record, ReferencedRecord>(
+                            record, [&](SqlSelectQueryBuilder selectQuery, auto const& primaryKeyField) {
+                                auto stmt = SqlStatement { _connection };
+                                stmt.Prepare(selectQuery.All());
+                                stmt.Execute(primaryKeyField.Value());
+
+                                auto referencedRecord = ReferencedRecord {};
+                                BindOutputColumns(referencedRecord, &stmt);
+                                ConfigureRelationAutoLoading(referencedRecord);
+
+                                while (stmt.FetchRow())
+                                {
+                                    each(referencedRecord);
+                                    BindOutputColumns(referencedRecord, &stmt);
+                                }
+                            });
+                    },
+            });
+        }
+        else if constexpr (IsHasOneThrough<FieldType>)
+        {
+            using ReferencedRecord = typename FieldType::ReferencedRecord;
+            using ThroughRecord = typename FieldType::ThroughRecord;
+            HasOneThrough<ReferencedRecord, ThroughRecord>& hasOneThrough = field;
+            hasOneThrough.SetAutoLoader(typename FieldType::Loader {
+                .loadReference =
+                    [this, &record, &hasOneThrough]() {
+                        LoadHasOneThrough<ReferencedRecord, ThroughRecord>(record, hasOneThrough);
+                    },
+            });
+        }
+        else if constexpr (IsHasManyThrough<FieldType>)
+        {
+            using ReferencedRecord = typename FieldType::ReferencedRecord;
+            using ThroughRecord = typename FieldType::ThroughRecord;
+            HasManyThrough<ReferencedRecord, ThroughRecord>& hasManyThrough = field;
+            hasManyThrough.SetAutoLoader(typename FieldType::Loader {
+                .count = [this, &record, &hasManyThrough]() -> size_t {
+                    // Load result for Count()
+                    size_t count = 0;
+                    CallOnHasManyThrough<ReferencedRecord, ThroughRecord>(
+                        record, [&](SqlSelectQueryBuilder& selectQuery, auto& primaryKeyField) {
+                            _stmt.Prepare(selectQuery.Count());
+                            _stmt.Execute(primaryKeyField.Value());
+                            if (_stmt.FetchRow())
+                                count = _stmt.GetColumn<size_t>(1);
+                            _stmt.CloseCursor();
+                        });
+                    return count;
+                },
+                .all =
+                    [this, &record, &hasManyThrough]() {
+                        // Load result for All()
+                        LoadHasManyThrough(record, hasManyThrough);
+                    },
+                .each =
+                    [this, &record, &hasManyThrough](auto const& each) {
+                        // Load result for Each()
+                        CallOnHasManyThrough<ReferencedRecord, ThroughRecord>(
+                            record, [&](SqlSelectQueryBuilder& selectQuery, auto& primaryKeyField) {
+                                auto stmt = SqlStatement { _connection };
+                                stmt.Prepare(selectQuery.All());
+                                stmt.Execute(primaryKeyField.Value());
+
+                                auto referencedRecord = ReferencedRecord {};
+                                BindOutputColumns(referencedRecord, &stmt);
+                                ConfigureRelationAutoLoading(referencedRecord);
+
+                                while (stmt.FetchRow())
+                                {
+                                    each(referencedRecord);
+                                    BindOutputColumns(referencedRecord, &stmt);
+                                }
+                            });
+                    },
+            });
+        }
+    });
+}

--- a/src/Lightweight/DataMapper/Detail.hpp
+++ b/src/Lightweight/DataMapper/Detail.hpp
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <format>
+#include <string>
+#include <type_traits>
+
+namespace detail
+{
+
+template <typename T, typename... Comps>
+concept OneOf = (std::same_as<T, Comps> || ...);
+
+struct StringBuilder
+{
+    std::string output;
+
+    std::string operator*() const& noexcept
+    {
+        return output;
+    }
+
+    std::string operator*() && noexcept
+    {
+        return std::move(output);
+    }
+
+    [[nodiscard]] bool empty() const noexcept
+    {
+        return output.empty();
+    }
+
+    template <typename T>
+    StringBuilder& operator<<(T&& value)
+    {
+        if constexpr (OneOf<T, std::string, std::string_view, char const*>)
+            output += value;
+        else
+            output += std::format("{}", std::forward<T>(value));
+        return *this;
+    }
+};
+
+} // namespace detail

--- a/src/Lightweight/DataMapper/Error.hpp
+++ b/src/Lightweight/DataMapper/Error.hpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <format>
+#include <stdexcept>
+#include <string_view>
+
+class SqlRequireLoadedError: public std::runtime_error
+{
+  public:
+    explicit SqlRequireLoadedError(std::string_view columnType):
+        std::runtime_error(std::format("Could not load the data record: {}", columnType))
+    {
+    }
+};

--- a/src/Lightweight/DataMapper/Field.hpp
+++ b/src/Lightweight/DataMapper/Field.hpp
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "../DataBinder/Core.hpp"
+#include "../SqlStatement.hpp"
+
+#include <reflection-cpp/reflection.hpp>
+
+struct SqlColumnNameView
+{
+    std::string_view name;
+};
+
+enum class FieldValueRequirement : uint8_t
+{
+    NULLABLE,
+    NOT_NULL,
+};
+
+constexpr inline FieldValueRequirement SqlNullable = FieldValueRequirement::NULLABLE;
+constexpr inline FieldValueRequirement SqlNotNullable = FieldValueRequirement::NULLABLE;
+
+enum class PrimaryKey : uint8_t
+{
+    No,
+    Manual,
+    AutoIncrement
+};
+
+namespace detail
+{
+
+// clang-format off
+
+template <typename T>
+struct IsStdOptionalType: std::false_type {};
+
+template <typename T>
+struct IsStdOptionalType<std::optional<T>>: std::true_type {};
+
+template <typename T>
+constexpr bool IsStdOptional = IsStdOptionalType<T>::value;
+
+template <typename T>
+concept FieldElementType = SqlInputParameterBinder<T> && SqlOutputColumnBinder<T>;
+
+// clang-format on
+
+} // namespace detail
+
+// Represents a single column in a table.
+//
+// The column name, index, and type are known at compile time.
+// If either name or index are not known at compile time, leave them at their default values,
+// but at least one of them msut be known.
+//
+// It is imperative that this data structure is an aggregate type, such that it works with C++20 reflection.
+template <detail::FieldElementType T, PrimaryKey IsPrimaryKeyValue = PrimaryKey::No>
+struct Field
+{
+    using ValueType = T;
+
+    // clang-format off
+    constexpr Field() noexcept = default;
+    constexpr Field(Field const&) noexcept = default;
+    constexpr Field& operator=(Field const&) noexcept = default;
+    constexpr Field(Field&&) noexcept = default;
+    constexpr Field& operator=(Field&&) noexcept = default;
+    constexpr ~Field() noexcept = default;
+    // clang-format on
+
+    template <typename... S>
+        requires std::constructible_from<T, S...>
+    constexpr Field(S&&... value) noexcept;
+
+    template <typename S>
+        requires std::constructible_from<T, S>
+    constexpr Field& operator=(S&& value) noexcept;
+
+    static constexpr auto IsOptional = detail::IsStdOptional<T>;
+    static constexpr auto IsMandatory = !IsOptional;
+    static constexpr auto IsPrimaryKey = IsPrimaryKeyValue != PrimaryKey::No;
+    static constexpr auto IsAutoIncrementPrimaryKey = IsPrimaryKeyValue == PrimaryKey::AutoIncrement;
+
+    constexpr std::weak_ordering operator<=>(Field const& other) const noexcept;
+
+    bool operator==(Field const& value) const noexcept = default;
+    bool operator!=(Field const& value) const noexcept = default;
+
+    bool operator==(T const& value) const noexcept;
+    bool operator!=(T const& value) const noexcept;
+
+    // Returns a string representation of the value, suitable for use in debugging and logging.
+    [[nodiscard]] std::string InspectValue() const;
+
+    void BindInputParameter(SQLSMALLINT parameterIndex, SqlStatement& stmt) const;
+    void BindOutputColumn(SQLSMALLINT outputIndex, SqlStatement& stmt);
+
+    constexpr void SetModified(bool value) noexcept;
+    [[nodiscard]] constexpr bool IsModified() const noexcept;
+    [[nodiscard]] constexpr T const& Value() const noexcept;
+    [[nodiscard]] constexpr T& MutableValue() noexcept;
+
+  private:
+    ValueType _value {};
+    bool _modified { false };
+};
+
+// clang-format off
+namespace detail
+{
+
+template <typename T>
+struct IsAutoIncrementPrimaryKeyField: std::false_type {};
+
+template <typename T>
+struct IsAutoIncrementPrimaryKeyField<Field<T, PrimaryKey::AutoIncrement>>: std::true_type {};
+
+template <typename T>
+struct IsFieldType: std::false_type {};
+
+template <typename T, PrimaryKey IsPrimaryKey>
+struct IsFieldType<Field<T, IsPrimaryKey>>: std::true_type {};
+
+} // namespace detail
+// clang-format on
+
+// Requires that T satisfies to be a field with storage and is considered a primary key.
+template <typename T>
+constexpr bool IsAutoIncrementPrimaryKey = detail::IsAutoIncrementPrimaryKeyField<T>::value;
+
+template <typename T>
+constexpr bool IsField = detail::IsFieldType<std::remove_cvref_t<T>>::value;
+
+template <detail::FieldElementType T, PrimaryKey IsPrimaryKey>
+template <typename... S>
+    requires std::constructible_from<T, S...>
+constexpr LIGHTWEIGHT_FORCE_INLINE Field<T, IsPrimaryKey>::Field(S&&... value) noexcept:
+    _value(std::forward<S>(value)...)
+{
+}
+
+template <detail::FieldElementType T, PrimaryKey IsPrimaryKey>
+template <typename S>
+    requires std::constructible_from<T, S>
+constexpr LIGHTWEIGHT_FORCE_INLINE Field<T, IsPrimaryKey>& Field<T, IsPrimaryKey>::operator=(S&& value) noexcept
+{
+    _value = std::forward<S>(value);
+    SetModified(true);
+    return *this;
+}
+
+template <detail::FieldElementType T, PrimaryKey IsPrimaryKey>
+constexpr std::weak_ordering LIGHTWEIGHT_FORCE_INLINE
+Field<T, IsPrimaryKey>::operator<=>(Field const& other) const noexcept
+{
+    return _value <=> other._value;
+}
+
+template <detail::FieldElementType T, PrimaryKey IsPrimaryKey>
+inline LIGHTWEIGHT_FORCE_INLINE bool Field<T, IsPrimaryKey>::operator==(T const& value) const noexcept
+{
+    return _value == value;
+}
+
+template <detail::FieldElementType T, PrimaryKey IsPrimaryKey>
+inline LIGHTWEIGHT_FORCE_INLINE bool Field<T, IsPrimaryKey>::operator!=(T const& value) const noexcept
+{
+    return _value != value;
+}
+
+template <detail::FieldElementType T, PrimaryKey IsPrimaryKey>
+inline LIGHTWEIGHT_FORCE_INLINE std::string Field<T, IsPrimaryKey>::InspectValue() const
+{
+    if constexpr (std::is_same_v<T, std::string>)
+    {
+        std::stringstream result;
+        result << std::quoted(_value, '\'');
+        return result.str();
+    }
+    else if constexpr (std::is_same_v<T, SqlTrimmedString>)
+    {
+        std::stringstream result;
+        result << std::quoted(_value.value, '\'');
+        return result.str();
+    }
+    else if constexpr (std::is_same_v<T, SqlText>)
+    {
+        std::stringstream result;
+        result << std::quoted(_value.value, '\'');
+        return result.str();
+    }
+    else if constexpr (std::is_same_v<T, SqlDate>)
+        return std::format("\'{}\'", _value.value);
+    else if constexpr (std::is_same_v<T, SqlTime>)
+        return std::format("\'{}\'", _value.value);
+    else if constexpr (std::is_same_v<T, SqlDateTime>)
+        return std::format("\'{}\'", _value.value());
+    else
+        return std::format("{}", _value);
+}
+
+template <detail::FieldElementType T, PrimaryKey IsPrimaryKey>
+inline LIGHTWEIGHT_FORCE_INLINE void Field<T, IsPrimaryKey>::BindInputParameter(SQLSMALLINT parameterIndex,
+                                                                                SqlStatement& stmt) const
+{
+    return stmt.BindInputParameter(parameterIndex, _value);
+}
+
+template <detail::FieldElementType T, PrimaryKey IsPrimaryKey>
+inline LIGHTWEIGHT_FORCE_INLINE void Field<T, IsPrimaryKey>::BindOutputColumn(SQLSMALLINT outputIndex,
+                                                                              SqlStatement& stmt)
+{
+    stmt.BindOutputColumn(outputIndex, &_value);
+}
+
+// ------------------------------------------------------------------------------------------------
+
+template <detail::FieldElementType T, PrimaryKey IsPrimaryKey>
+constexpr LIGHTWEIGHT_FORCE_INLINE void Field<T, IsPrimaryKey>::SetModified(bool value) noexcept
+{
+    _modified = value;
+}
+
+template <detail::FieldElementType T, PrimaryKey IsPrimaryKey>
+constexpr LIGHTWEIGHT_FORCE_INLINE bool Field<T, IsPrimaryKey>::IsModified() const noexcept
+{
+    return _modified;
+}
+
+template <detail::FieldElementType T, PrimaryKey IsPrimaryKey>
+constexpr LIGHTWEIGHT_FORCE_INLINE T const& Field<T, IsPrimaryKey>::Value() const noexcept
+{
+    return _value;
+}
+
+template <detail::FieldElementType T, PrimaryKey IsPrimaryKey>
+constexpr LIGHTWEIGHT_FORCE_INLINE T& Field<T, IsPrimaryKey>::MutableValue() noexcept
+{
+    return _value;
+}
+
+template <detail::FieldElementType T, PrimaryKey IsPrimaryKey>
+struct SqlDataBinder<Field<T, IsPrimaryKey>>
+{
+    using ValueType = Field<T, IsPrimaryKey>;
+
+    static constexpr auto ColumnType = SqlDataBinder<T>::ColumnType;
+
+    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN InputParameter(SQLHSTMT stmt,
+                                                             SQLUSMALLINT column,
+                                                             ValueType const& value,
+                                                             SqlDataBinderCallback& cb)
+    {
+        return SqlDataBinder<T>::InputParameter(stmt, column, value.Value(), cb);
+    }
+
+    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN
+    OutputColumn(SQLHSTMT stmt, SQLUSMALLINT column, ValueType* result, SQLLEN* indicator, SqlDataBinderCallback& cb)
+    {
+        auto const sqlReturn = SqlDataBinder<T>::OutputColumn(stmt, column, &result->MutableValue(), indicator, cb);
+        cb.PlanPostProcessOutputColumn([result]() { result->SetModified(true); });
+        return sqlReturn;
+    }
+
+    static LIGHTWEIGHT_FORCE_INLINE SQLRETURN GetColumn(SQLHSTMT stmt,
+                                                        SQLUSMALLINT column,
+                                                        ValueType* result,
+                                                        SQLLEN* indicator,
+                                                        SqlDataBinderCallback const& cb) noexcept
+    {
+        auto const sqlReturn = SqlDataBinder<T>::GetColumn(stmt, column, &result->emplace(), indicator, cb);
+        if (SQL_SUCCEEDED(sqlReturn))
+            result->SetModified(true);
+        return sqlReturn;
+    }
+};
+
+template <detail::FieldElementType T, PrimaryKey IsPrimaryKey>
+struct std::formatter<Field<T, IsPrimaryKey>>: std::formatter<T>
+{
+    template <typename FormatContext>
+    auto format(Field<T, IsPrimaryKey> const& field, FormatContext& ctx)
+    {
+        return formatter<T>::format(field.InspectValue(), ctx);
+    }
+};

--- a/src/Lightweight/DataMapper/HasMany.hpp
+++ b/src/Lightweight/DataMapper/HasMany.hpp
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "../DataBinder/Core.hpp"
+#include "../DataBinder/SqlNullValue.hpp"
+#include "../SqlStatement.hpp"
+#include "BelongsTo.hpp"
+#include "Field.hpp"
+
+#include <reflection-cpp/reflection.hpp>
+
+#include <compare>
+#include <memory>
+#include <optional>
+#include <type_traits>
+#include <vector>
+
+// This HasMany<OtherRecord> represents a simple one-to-many relationship between two records.
+//
+// The HasMany<OtherRecord> is a member of the "one" side of the relationship.
+//
+// This implemenation of `HasMany<OtherRecord>` must have only one `BelongsTo` member
+// that points back to this "one" side.
+template <typename OtherRecord>
+class HasMany
+{
+  public:
+    using ReferencedRecord = OtherRecord;
+    using ReferencedRecordList = std::vector<std::shared_ptr<OtherRecord>>;
+
+    // Record type of the "many" side of the relationship.
+    using value_type = OtherRecord;
+    using iterator = typename ReferencedRecordList::iterator;
+    using const_iterator = typename ReferencedRecordList::const_iterator;
+
+    // Retrieves the list of loaded records.
+    [[nodiscard]] ReferencedRecordList const& All() const noexcept;
+
+    // Retrieves the list of records as mutable reference.
+    [[nodiscard]] ReferencedRecordList& All() noexcept;
+
+    template <typename Callable>
+    void Each(Callable const& callable);
+
+    // Emplaces the given list of records.
+    ReferencedRecordList& Emplace(ReferencedRecordList&& records) noexcept;
+
+    [[nodiscard]] std::size_t Count() const noexcept;
+    [[nodiscard]] bool IsEmpty() const noexcept;
+    [[nodiscard]] OtherRecord const& At(std::size_t index) const;
+    [[nodiscard]] OtherRecord& At(std::size_t index);
+    [[nodiscard]] OtherRecord const& operator[](std::size_t index) const;
+    [[nodiscard]] OtherRecord& operator[](std::size_t index);
+
+    iterator begin() noexcept;
+    iterator end() noexcept;
+    const_iterator begin() const noexcept;
+    const_iterator end() const noexcept;
+
+    constexpr std::weak_ordering operator<=>(HasMany<OtherRecord> const& other) const noexcept = default;
+
+    constexpr bool operator==(HasMany<OtherRecord> const& other) const noexcept = default;
+    constexpr bool operator!=(HasMany<OtherRecord> const& other) const noexcept = default;
+
+    struct Loader
+    {
+        std::function<size_t()> count {};
+        std::function<void()> all {};
+        std::function<void(std::function<void(ReferencedRecord const&)>)> each {};
+    };
+
+    void SetAutoLoader(Loader loader) noexcept;
+
+  private:
+    void RequireLoaded();
+
+    Loader _loader;
+    std::optional<ReferencedRecordList> _records;
+    std::optional<size_t> _count;
+};
+
+template <typename T>
+constexpr bool IsHasMany = IsSpecializationOf<HasMany, T>;
+
+template <typename OtherRecord>
+inline LIGHTWEIGHT_FORCE_INLINE void HasMany<OtherRecord>::SetAutoLoader(Loader loader) noexcept
+{
+    _loader = std::move(loader);
+}
+
+template <typename OtherRecord>
+inline LIGHTWEIGHT_FORCE_INLINE void HasMany<OtherRecord>::RequireLoaded()
+{
+    if (!_records)
+        _loader.all();
+}
+
+template <typename OtherRecord>
+inline LIGHTWEIGHT_FORCE_INLINE HasMany<OtherRecord>::ReferencedRecordList& HasMany<OtherRecord>::Emplace(
+    ReferencedRecordList&& records) noexcept
+{
+    _records = { std::move(records) };
+    return *_records;
+}
+
+template <typename OtherRecord>
+inline LIGHTWEIGHT_FORCE_INLINE HasMany<OtherRecord>::ReferencedRecordList& HasMany<OtherRecord>::All() noexcept
+{
+    RequireLoaded();
+    return *_records;
+}
+
+template <typename OtherRecord>
+template <typename Callable>
+void HasMany<OtherRecord>::Each(Callable const& callable)
+{
+    if (!_records && _loader.each)
+    {
+        _loader.each(callable);
+        return;
+    }
+
+    for (auto const& record: All())
+        callable(*record);
+}
+
+template <typename OtherRecord>
+inline LIGHTWEIGHT_FORCE_INLINE HasMany<OtherRecord>::ReferencedRecordList const& HasMany<OtherRecord>::All()
+    const noexcept
+{
+    RequireLoaded();
+    return *_records;
+}
+
+template <typename OtherRecord>
+inline LIGHTWEIGHT_FORCE_INLINE std::size_t HasMany<OtherRecord>::Count() const noexcept
+{
+    if (_records)
+        return _records->size();
+
+    if (!_count)
+        const_cast<HasMany<OtherRecord>*>(this)->_count = _loader.count();
+
+    return *_count;
+}
+
+template <typename OtherRecord>
+inline LIGHTWEIGHT_FORCE_INLINE bool HasMany<OtherRecord>::IsEmpty() const noexcept
+{
+    return Count() == 0;
+}
+
+template <typename OtherRecord>
+inline LIGHTWEIGHT_FORCE_INLINE OtherRecord const& HasMany<OtherRecord>::At(std::size_t index) const
+{
+    RequireLoaded();
+    return *_records->at(index);
+}
+
+template <typename OtherRecord>
+inline LIGHTWEIGHT_FORCE_INLINE OtherRecord& HasMany<OtherRecord>::At(std::size_t index)
+{
+    RequireLoaded();
+    return *_records->at(index);
+}
+
+template <typename OtherRecord>
+inline LIGHTWEIGHT_FORCE_INLINE OtherRecord const& HasMany<OtherRecord>::operator[](std::size_t index) const
+{
+    RequireLoaded();
+    return *(*_records)[index];
+}
+
+template <typename OtherRecord>
+inline LIGHTWEIGHT_FORCE_INLINE OtherRecord& HasMany<OtherRecord>::operator[](std::size_t index)
+{
+    RequireLoaded();
+    return *(*_records)[index];
+}
+
+template <typename OtherRecord>
+inline LIGHTWEIGHT_FORCE_INLINE HasMany<OtherRecord>::iterator HasMany<OtherRecord>::begin() noexcept
+{
+    RequireLoaded();
+    return _records->begin();
+}
+
+template <typename OtherRecord>
+inline LIGHTWEIGHT_FORCE_INLINE HasMany<OtherRecord>::iterator HasMany<OtherRecord>::end() noexcept
+{
+    RequireLoaded();
+    return _records->end();
+}
+
+template <typename OtherRecord>
+inline LIGHTWEIGHT_FORCE_INLINE HasMany<OtherRecord>::const_iterator HasMany<OtherRecord>::begin() const noexcept
+{
+    RequireLoaded();
+    return _records->begin();
+}
+
+template <typename OtherRecord>
+inline LIGHTWEIGHT_FORCE_INLINE HasMany<OtherRecord>::const_iterator HasMany<OtherRecord>::end() const noexcept
+{
+    RequireLoaded();
+    return _records->end();
+}

--- a/src/Lightweight/DataMapper/HasManyThrough.hpp
+++ b/src/Lightweight/DataMapper/HasManyThrough.hpp
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "../Utils.hpp"
+#include "Error.hpp"
+
+#include <reflection-cpp/reflection.hpp>
+
+#include <compare>
+#include <functional>
+#include <memory>
+#include <vector>
+
+// This HasManyThrough<ReferencedRecord, ThroughRecord> represents a many-to-many relationship between two records
+// through a third record.
+template <typename ReferencedRecordT, typename ThroughRecordT>
+class HasManyThrough
+{
+  public:
+    using ThroughRecord = ThroughRecordT;
+    using ReferencedRecord = ReferencedRecordT;
+    using ReferencedRecordList = std::vector<std::shared_ptr<ReferencedRecord>>;
+
+    using value_type = ReferencedRecord;
+    using iterator = typename ReferencedRecordList::iterator;
+    using const_iterator = typename ReferencedRecordList::const_iterator;
+
+    // Retrieves the list of loaded records.
+    [[nodiscard]] ReferencedRecordList const& All() const noexcept;
+
+    // Retrieves the list of records as mutable reference.
+    [[nodiscard]] ReferencedRecordList& All() noexcept;
+
+    // Emplaces the given list of records.
+    ReferencedRecordList& Emplace(ReferencedRecordList&& records) noexcept;
+
+    [[nodiscard]] std::size_t Count() const;
+    [[nodiscard]] std::size_t IsEmpty() const;
+    [[nodiscard]] ReferencedRecord const& At(std::size_t index) const;
+    [[nodiscard]] ReferencedRecord& At(std::size_t index);
+    [[nodiscard]] ReferencedRecord const& operator[](std::size_t index) const;
+    [[nodiscard]] ReferencedRecord& operator[](std::size_t index);
+
+    iterator begin() noexcept;
+    iterator end() noexcept;
+    const_iterator begin() const noexcept;
+    const_iterator end() const noexcept;
+
+    std::weak_ordering operator<=>(HasManyThrough const& other) const noexcept = default;
+
+    struct Loader
+    {
+        std::function<size_t()> count;
+        std::function<void()> all;
+        std::function<void(std::function<void(ReferencedRecord const&)>)> each;
+    };
+
+    void SetAutoLoader(Loader loader) noexcept
+    {
+        _loader = std::move(loader);
+    }
+
+    void Reload()
+    {
+        _count = std::nullopt;
+        _records = std::nullopt;
+        RequireLoaded();
+    }
+
+    template <typename Callable>
+    void Each(Callable const& callable)
+    {
+        if (!_records && _loader.each)
+        {
+            _loader.each(callable);
+            return;
+        }
+
+        for (auto const& record: All())
+            callable(*record);
+    }
+
+  private:
+    void RequireLoaded()
+    {
+        if (_records)
+            return;
+
+        if (_loader.all)
+            _loader.all();
+
+        if (!_records)
+            throw SqlRequireLoadedError(Reflection::TypeName<std::remove_cvref_t<decltype(*this)>>);
+    }
+
+    Loader _loader;
+
+    std::optional<size_t> _count;
+    std::optional<ReferencedRecordList> _records;
+};
+
+template <typename T>
+constexpr bool IsHasManyThrough = IsSpecializationOf<HasManyThrough, T>;
+
+template <typename ReferencedRecordT, typename ThroughRecordT>
+HasManyThrough<ReferencedRecordT, ThroughRecordT>::ReferencedRecordList const& HasManyThrough<ReferencedRecordT,
+                                                                                              ThroughRecordT>::All()
+    const noexcept
+{
+    const_cast<HasManyThrough*>(this)->RequireLoaded();
+
+    return _records.value();
+}
+
+template <typename ReferencedRecordT, typename ThroughRecordT>
+HasManyThrough<ReferencedRecordT, ThroughRecordT>::ReferencedRecordList& HasManyThrough<ReferencedRecordT,
+                                                                                        ThroughRecordT>::All() noexcept
+{
+    RequireLoaded();
+
+    return _records.value();
+}
+
+template <typename ReferencedRecordT, typename ThroughRecordT>
+HasManyThrough<ReferencedRecordT, ThroughRecordT>::ReferencedRecordList& HasManyThrough<
+    ReferencedRecordT,
+    ThroughRecordT>::Emplace(ReferencedRecordList&& records) noexcept
+{
+    _records = { std::move(records) };
+    _count = _records->size();
+    return *_records;
+}
+
+template <typename ReferencedRecordT, typename ThroughRecordT>
+std::size_t HasManyThrough<ReferencedRecordT, ThroughRecordT>::Count() const
+{
+    if (_records)
+        return _records->size();
+
+    if (!_count)
+        const_cast<HasManyThrough<ReferencedRecordT, ThroughRecordT>*>(this)->_count = _loader.count();
+
+    return *_count;
+}
+
+template <typename ReferencedRecordT, typename ThroughRecordT>
+std::size_t HasManyThrough<ReferencedRecordT, ThroughRecordT>::IsEmpty() const
+{
+    return Count() == 0;
+}
+
+template <typename ReferencedRecordT, typename ThroughRecordT>
+HasManyThrough<ReferencedRecordT, ThroughRecordT>::ReferencedRecord const& HasManyThrough<
+    ReferencedRecordT,
+    ThroughRecordT>::At(std::size_t index) const
+{
+    return *All().at(index);
+}
+
+template <typename ReferencedRecordT, typename ThroughRecordT>
+HasManyThrough<ReferencedRecordT, ThroughRecordT>::ReferencedRecord& HasManyThrough<ReferencedRecordT, ThroughRecordT>::
+    At(std::size_t index)
+{
+    return *All().at(index);
+}
+
+template <typename ReferencedRecordT, typename ThroughRecordT>
+HasManyThrough<ReferencedRecordT, ThroughRecordT>::ReferencedRecord const& HasManyThrough<
+    ReferencedRecordT,
+    ThroughRecordT>::operator[](std::size_t index) const
+{
+    return *All()[index];
+}
+
+template <typename ReferencedRecordT, typename ThroughRecordT>
+HasManyThrough<ReferencedRecordT, ThroughRecordT>::ReferencedRecord& HasManyThrough<ReferencedRecordT, ThroughRecordT>::
+operator[](std::size_t index)
+{
+    return *All()[index];
+}
+
+template <typename ReferencedRecordT, typename ThroughRecordT>
+HasManyThrough<ReferencedRecordT, ThroughRecordT>::iterator HasManyThrough<ReferencedRecordT,
+                                                                           ThroughRecordT>::begin() noexcept
+{
+    return All().begin();
+}
+
+template <typename ReferencedRecordT, typename ThroughRecordT>
+HasManyThrough<ReferencedRecordT, ThroughRecordT>::iterator HasManyThrough<ReferencedRecordT,
+                                                                           ThroughRecordT>::end() noexcept
+{
+    return All().end();
+}
+
+template <typename ReferencedRecordT, typename ThroughRecordT>
+HasManyThrough<ReferencedRecordT, ThroughRecordT>::const_iterator HasManyThrough<ReferencedRecordT,
+                                                                                 ThroughRecordT>::begin() const noexcept
+{
+    return All().begin();
+}
+
+template <typename ReferencedRecordT, typename ThroughRecordT>
+HasManyThrough<ReferencedRecordT, ThroughRecordT>::const_iterator HasManyThrough<ReferencedRecordT,
+                                                                                 ThroughRecordT>::end() const noexcept
+{
+    return All().end();
+}

--- a/src/Lightweight/DataMapper/HasOneThrough.hpp
+++ b/src/Lightweight/DataMapper/HasOneThrough.hpp
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "../SqlStatement.hpp"
+#include "../Utils.hpp"
+#include "Error.hpp"
+
+#include <compare>
+#include <memory>
+#include <type_traits>
+
+// Represents a one-to-one relationship through a join table.
+//
+// The `OtherField` parameter is the field in the join table that references the other record.
+// The `ThroughField` parameter is the field in the join table that references the current record.
+template <typename OtherTable, typename ThroughTable>
+class HasOneThrough
+{
+  public:
+    using ThroughRecord = ThroughTable;
+    using ReferencedRecord = OtherTable;
+
+    // clang-format off
+    LIGHTWEIGHT_FORCE_INLINE constexpr void EmplaceRecord(std::shared_ptr<ReferencedRecord> record) { _record = std::move(record); }
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord& Record() noexcept { RequireLoaded(); return *_record.get(); }
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord const& Record() const noexcept { RequireLoaded(); return *_record.get(); }
+
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr bool IsLoaded() const noexcept { return _record.get() != nullptr; }
+    LIGHTWEIGHT_FORCE_INLINE void Unload() noexcept { _record = std::nullopt; }
+
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord& operator*() noexcept { RequireLoaded(); return *_record; }
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord const& operator*() const noexcept { RequireLoaded(); return *_record; }
+
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord* operator->() noexcept { RequireLoaded(); return &_record.get(); }
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr ReferencedRecord const* operator->() const noexcept { RequireLoaded(); return &_record.get(); }
+    // clang-format on
+
+    std::weak_ordering operator<=>(HasOneThrough const& other) const noexcept = default;
+
+    struct Loader
+    {
+        std::function<void()> loadReference {};
+    };
+
+    void SetAutoLoader(Loader loader)
+    {
+        _loader = std::move(loader);
+    }
+
+  private:
+    void RequireLoaded() const
+    {
+        if (IsLoaded())
+            return;
+
+        if (_loader.loadReference)
+            _loader.loadReference();
+
+        if (!IsLoaded())
+            throw SqlRequireLoadedError { Reflection::TypeName<std::remove_cvref_t<decltype(*this)>> };
+    }
+
+    Loader _loader {};
+
+    // We use shared_ptr to not require ReferencedRecord to be declared before HasOneThrough.
+    std::shared_ptr<ReferencedRecord> _record {};
+};
+
+namespace detail
+{
+template <typename T>
+struct IsHasOneThrough: std::false_type
+{
+};
+
+template <typename OtherTable, typename ThroughTable>
+struct IsHasOneThrough<HasOneThrough<OtherTable, ThroughTable>>: std::true_type
+{
+};
+} // namespace detail
+
+template <typename T>
+constexpr bool IsHasOneThrough = detail::IsHasOneThrough<std::remove_cvref_t<T>>::value;

--- a/src/Lightweight/DataMapper/Logger.cpp
+++ b/src/Lightweight/DataMapper/Logger.cpp
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "Detail.hpp"
+#include "Field.hpp"
+#include "Logger.hpp"
+
+#include <chrono>
+#include <string_view>
+
+class StandardQueryLogger: public QueryLogger
+{
+  private:
+    std::chrono::steady_clock::time_point m_startedAt;
+    std::string m_query;
+    // FieldList m_output;
+    size_t m_rowCount {};
+
+  public:
+    LIGHTWEIGHT_API void QueryStart(std::string_view query, FieldList const& /*output*/) override
+    {
+        m_startedAt = std::chrono::steady_clock::now();
+        m_query = query;
+        // m_output = output;
+        m_rowCount = 0;
+    }
+
+    LIGHTWEIGHT_API void QueryNextRow(AbstractRecord const& /*record*/) override
+    {
+        ++m_rowCount;
+    }
+
+    LIGHTWEIGHT_API void QueryEnd() override
+    {
+        auto const stoppedAt = std::chrono::steady_clock::now();
+        auto const duration = std::chrono::duration_cast<std::chrono::microseconds>(stoppedAt - m_startedAt);
+        auto const seconds = std::chrono::duration_cast<std::chrono::seconds>(duration);
+        auto const microseconds = std::chrono::duration_cast<std::chrono::microseconds>(duration - seconds);
+        auto const durationStr = std::format("{}.{:06}", seconds.count(), microseconds.count());
+
+        auto const rowCountStr = m_rowCount == 0   ? ""
+                                 : m_rowCount == 1 ? " [1 row]"
+                                                   : std::format(" [{} rows]", m_rowCount);
+
+#if 0
+        if (m_output.empty())
+        {
+            std::println("[{}]{} {}", durationStr, rowCountStr, m_query);
+            return;
+        }
+
+        detail::StringBuilder output;
+
+        for (AbstractField const* field: m_output)
+        {
+            if (!output.empty())
+                output << ", ";
+            output << field->Name().name << '=' << field->InspectValue();
+        }
+
+        std::println("[{}]{} {} WITH [{}]", durationStr, rowCountStr, m_query, *output);
+#else
+        std::println("[{}]{} {}", durationStr, rowCountStr, m_query);
+#endif
+    }
+};
+
+static QueryLogger theNullLogger;
+
+QueryLogger* QueryLogger::NullLogger() noexcept
+{
+    return &theNullLogger;
+}
+
+static StandardQueryLogger theStandardLogger;
+
+QueryLogger* QueryLogger::StandardLogger() noexcept
+{
+    return &theStandardLogger;
+}
+
+QueryLogger* QueryLogger::m_instance = QueryLogger::NullLogger();

--- a/src/Lightweight/DataMapper/Logger.hpp
+++ b/src/Lightweight/DataMapper/Logger.hpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "../Api.hpp"
+
+#include <string_view>
+#include <vector>
+
+class AbstractField;
+struct AbstractRecord;
+
+class QueryLogger
+{
+  public:
+    virtual ~QueryLogger() = default;
+
+    using FieldList = std::vector<AbstractField*>;
+
+    LIGHTWEIGHT_API virtual void QueryStart(std::string_view /*query*/, FieldList const& /*output*/) {}
+    LIGHTWEIGHT_API virtual void QueryNextRow(AbstractRecord const& /*DataMapper*/) {}
+    LIGHTWEIGHT_API virtual void QueryEnd() {}
+
+    LIGHTWEIGHT_API static void Set(QueryLogger* next) noexcept
+    {
+        m_instance = next;
+    }
+
+    LIGHTWEIGHT_API static QueryLogger& Get() noexcept
+    {
+        return *m_instance;
+    }
+
+    LIGHTWEIGHT_API static QueryLogger* NullLogger() noexcept;
+    LIGHTWEIGHT_API static QueryLogger* StandardLogger() noexcept;
+
+  private:
+    LIGHTWEIGHT_API static QueryLogger* m_instance;
+};
+
+namespace detail
+{
+
+    struct SqlScopedModelQueryLogger
+    {
+        using FieldList = QueryLogger::FieldList;
+
+        LIGHTWEIGHT_FORCE_INLINE SqlScopedModelQueryLogger(std::string_view query, FieldList const& output)
+        {
+            QueryLogger::Get().QueryStart(query, output);
+        }
+
+        // TODO(pr): find equivalent to that
+        //           probably through Reflection::Inspect()
+        // SqlScopedModelQueryLogger& operator+=(AbstractRecord const& record)
+        // {
+        //     QueryLogger::Get().QueryNextRow(record);
+        //     return *this;
+        // }
+
+        LIGHTWEIGHT_FORCE_INLINE ~SqlScopedModelQueryLogger()
+        {
+            QueryLogger::Get().QueryEnd();
+        }
+    };
+
+} // namespace detail

--- a/src/Lightweight/DataMapper/README.md
+++ b/src/Lightweight/DataMapper/README.md
@@ -1,0 +1,81 @@
+# Lightweight Model API
+
+The Lightweight Model API is a lightweight ORM that allows you to interact with your database using a simple and intuitive API.
+It is designed to be easy to use while being as efficient as possible.
+
+This API was inspired by **Active Record** pattern and API from Ruby on Rails.
+
+## Features
+
+- **Simple & Intuitive API**: The API is designed to be as simple as possible.
+- **Efficient**: The API is designed to be as efficient as possible.
+
+## Example
+
+```cpp
+#include <Lightweight/Model/All.hpp>
+#include <print>
+
+struct Book;
+
+struct Author: Model::Record<User>
+{
+    Model::Field<std::string, 2, "name"> name;
+    Model::HasMany<Book> books;
+};
+
+struct Book: Model::Record<Book>
+{
+    Model::Field<std::string, 2, "title"> title;
+    Model::Field<std::string, 3, "isbn"> isbn;
+    Model::BelongsTo<Author, 4, "author_id"> author;
+};
+
+void demo()
+{
+    Model::CreateTables<Author, Book>();
+
+    Author author;
+    author.name = "Bjarne Stroustrup";
+    author.Save().or_else(std::abort);
+
+    Book book;
+    book.title = "The C++ Programming Language";
+    book.isbn = "978-0-321-56384-2";
+    book.author = author;
+    book.Save().or_else(std::abort);
+
+    auto books = Book::All().or_else(std::abort);
+    for (auto book: books)
+        std::println("{}", book);
+
+    std::println("{} has {} books", author.name, author.books.Count());
+
+    author.Destroy();
+    book.Destroy();
+}
+```
+
+## TODO: Open Refactors
+
+- [ ] Consider reintroducing `Model::Record<T, TableName, PrimaryKeyType, PrimaryKeyName>`
+- [x] Support (join) Associations (https://guides.rubyonrails.org/association_basics.html) (e.g. `Author::All().Join<Book>().Where<Book::isbn == "978-0-321-56384-2"`) (may need some higher level query builder)
+- [ ] Consider changing `SqlVariant` into a wrapped `std::variant` to allow convenient conversions between types (e.g. `SqlVariant v = 42; v.ToInt() == 42; v.As<int>() == 42; v.As<std::string>() == "42";`)
+
+## Open TODOs
+
+- [x] [Lightweight] Add custom type `SqlText` for `TEXT` fields
+- [x] Add std::formatter for `Record<T>`
+- [x] Add test for `BelongsTo<>` (including eager & lazy-loading check)
+- [x] Add test for `HasOne<>` (including eager & lazy-loading check)
+- [x] Add test for `HasMany<>` (including eager & lazy-loading check)
+- [x] Differenciate between VARCHAR (`std::string`) and TEXT (maybe `SqlText<std::string>`?)
+- [x] Make logging more useful, adding payload data
+- [x] remove debug prints
+- [x] add proper trace logging
+- [x] Add `HasManyThrough<>` association
+- [x] Add `HasOneThrough<>` association
+- [ ] Add `HasAndBelongsToMany<>` association
+- [ ] Add SQL query caching
+- [x] Add lazy loading constraints (e.g. something similar to `Book::All().Where<Book::author_id == 1>`)
+- [ ] Add ability to configure PK's auto-increment to be server-side (default) vs client-side. this must be a compile-time option (via template parameter)

--- a/src/Lightweight/DataMapper/RecordId.hpp
+++ b/src/Lightweight/DataMapper/RecordId.hpp
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+struct RecordId
+{
+    unsigned long long value {};
+};

--- a/src/Lightweight/SqlQuery/Select.hpp
+++ b/src/Lightweight/SqlQuery/Select.hpp
@@ -4,6 +4,8 @@
 
 #include "Core.hpp"
 
+#include <reflection-cpp/reflection.hpp>
+
 enum class SqlResultOrdering : uint8_t
 {
     ASCENDING,
@@ -76,6 +78,9 @@ class [[nodiscard]] SqlSelectQueryBuilder final: public detail::SqlWhereClauseBu
     LIGHTWEIGHT_API SqlSelectQueryBuilder& Fields(std::initializer_list<std::string_view> const& fieldNames,
                                                   std::string_view tableName);
 
+    template <typename Record>
+    LIGHTWEIGHT_API SqlSelectQueryBuilder& Fields();
+
     // Adds a single column with an alias to the SELECT clause.
     LIGHTWEIGHT_API SqlSelectQueryBuilder& FieldAs(std::string_view const& fieldName, std::string_view const& alias);
 
@@ -89,6 +94,9 @@ class [[nodiscard]] SqlSelectQueryBuilder final: public detail::SqlWhereClauseBu
 
     // Constructs or extends a GROUP BY clause.
     LIGHTWEIGHT_API SqlSelectQueryBuilder& GroupBy(std::string_view columnName);
+
+    template <typename Callable>
+    SqlSelectQueryBuilder& Build(Callable const& callable);
 
     // Finalizes building the query as SELECT COUNT(*) ... query.
     LIGHTWEIGHT_API ComposedQuery Count();
@@ -135,3 +143,22 @@ SqlSelectQueryBuilder& SqlSelectQueryBuilder::Fields(std::string_view const& fir
     m_query.fields += fragment.str();
     return *this;
 }
+
+template <typename Callable>
+inline LIGHTWEIGHT_FORCE_INLINE SqlSelectQueryBuilder& SqlSelectQueryBuilder::Build(Callable const& callable)
+{
+    callable(*this);
+    return *this;
+}
+
+// template <typename Record>
+// inline LIGHTWEIGHT_FORCE_INLINE SqlSelectQueryBuilder& SqlSelectQueryBuilder::Fields()
+// {
+//     Reflection::EnumerateMembers<Record>([this]<size_t FieldIndex, typename FieldType>() {
+//         if constexpr (FieldWithStorage<FieldType>)
+//         {
+//             std::ignore = Field(FieldNameOf<FieldIndex, Record>());
+//         }
+//     });
+//     return *this;
+// }

--- a/src/Lightweight/SqlStatement.cpp
+++ b/src/Lightweight/SqlStatement.cpp
@@ -183,6 +183,7 @@ bool SqlStatement::FetchRow()
     {
         case SQL_NO_DATA:
             SQLCloseCursor(m_hStmt);
+            m_data->postProcessOutputColumnCallbacks.clear();
             return false;
         default:
             RequireSuccess(sqlResult);

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -361,7 +361,8 @@ inline LIGHTWEIGHT_FORCE_INLINE void SqlStatement::BindOutputColumn(SQLUSMALLINT
 {
     RequireIndicators();
 
-    RequireSuccess(SqlDataBinder<T>::OutputColumn(m_hStmt, columnIndex, arg, GetIndicatorForColumn(columnIndex), *this));
+    RequireSuccess(
+        SqlDataBinder<T>::OutputColumn(m_hStmt, columnIndex, arg, GetIndicatorForColumn(columnIndex), *this));
 }
 
 template <SqlInputParameterBinder Arg>
@@ -504,12 +505,6 @@ namespace detail
 
 // is_specialization_of<> is inspired by:
 // https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2098r1.pdf
-
-template <template <typename...> class T, typename U>
-struct is_specialization_of: std::false_type {};
-
-template <template <typename...> class T, typename... Us>
-struct is_specialization_of<T, T<Us...>>: std::true_type {};
 
 template <typename T>
 concept SqlNullableType = (std::same_as<T, SqlVariant> || is_specialization_of<std::optional, T>::value);

--- a/src/Lightweight/Utils.hpp
+++ b/src/Lightweight/Utils.hpp
@@ -20,4 +20,26 @@ constexpr auto Finally(auto&& cleanupRoutine) noexcept
     return Finally { std::forward<decltype(cleanupRoutine)>(cleanupRoutine) };
 }
 
+template <template <typename...> class T, typename U>
+struct is_specialization_of: std::false_type {};
+
+template <template <typename...> class T, typename... Us>
+struct is_specialization_of<T, T<Us...>>: std::true_type {};
+
+template <typename T>
+struct MemberClassTypeHelper;
+
+template <typename M, typename T>
+struct MemberClassTypeHelper<M T::*>
+{
+    using type = std::remove_cvref_t<T>;
+};
+
 } // namespace detail
+
+template <template <typename...> class S, class T>
+concept IsSpecializationOf = detail::is_specialization_of<S, T>::value;
+
+template <typename T>
+using MemberClassType = typename detail::MemberClassTypeHelper<T>::type;
+

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(LightweightTest PRIVATE ${TEST_LIBRARIES})
 set(SOURCE_FILES
     CoreTests.cpp
     DataBinderTests.cpp
+    DataMapperTests.cpp
     QueryBuilderTests.cpp
     UnicodeConverterTests.cpp
 )

--- a/src/tests/DataMapperTests.cpp
+++ b/src/tests/DataMapperTests.cpp
@@ -1,0 +1,485 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "Utils.hpp"
+
+#include <Lightweight/DataMapper/DataMapper.hpp>
+
+#include <reflection-cpp/reflection.hpp>
+
+#include <catch2/catch_session.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <ostream>
+
+std::ostream& operator<<(std::ostream& os, RecordId const& id)
+{
+    return os << id.value;
+}
+
+template <typename T, PrimaryKey IsPrimaryKeyValue>
+std::ostream& operator<<(std::ostream& os, Field<std::optional<T>, IsPrimaryKeyValue> const& field)
+{
+    if (field.Value())
+        return os << std::format("Field<{}> {{ {}, {} }}",
+                                 Reflection::TypeName<T>,
+                                 *field.Value(),
+                                 field.IsModified() ? "modified" : "not modified");
+    else
+        return os << "NULL";
+}
+
+template <typename T, PrimaryKey IsPrimaryKeyValue>
+std::ostream& operator<<(std::ostream& os, Field<T, IsPrimaryKeyValue> const& field)
+{
+    return os << std::format("Field<{}> {{ {}, {} }}",
+                             Reflection::TypeName<T>,
+                             field.Value(),
+                             field.IsModified() ? "modified" : "not modified");
+}
+
+struct Person
+{
+    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<SqlTrimmedFixedString<25>> name;
+    Field<bool> is_active { true };
+    Field<std::optional<int>> age;
+};
+
+// This is a test to only partially query a table row (a few columns)
+struct PersonName
+{
+    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<SqlTrimmedFixedString<25>> name;
+
+    static constexpr std::string_view TableName = RecordTableName<Person>;
+};
+
+TEST_CASE_METHOD(SqlTestFixture, "CRUD", "[DataMapper]")
+{
+    auto dm = DataMapper();
+    dm.CreateTable<Person>();
+
+    // Create
+    auto person = Person {};
+    person.name = "John Doe";
+    person.is_active = true;
+
+    REQUIRE(person.id == 0);
+    dm.Create(person);
+    REQUIRE(person.id.Value() != 0);
+
+    // Read (by primary key)
+    auto po = dm.QuerySingle<Person>(person.id);
+    auto p = po.value();
+    CHECK(p.id == person.id);
+    CHECK(p.name == person.name);
+    CHECK(p.is_active == person.is_active);
+    CHECK(p.age.Value().has_value() == false);
+
+    // Update
+    person.age = 42;
+    person.is_active = false;
+    dm.Update(person);
+
+    po = dm.QuerySingle<Person>(person.id);
+    p = po.value();
+    CHECK(p.id == person.id);
+    CHECK(p.name == person.name);
+    CHECK(p.is_active == person.is_active);
+    CHECK(p.age.Value().value_or(0) == 42);
+
+    // Delete
+    auto const numRowsAffected = dm.Delete(person);
+    CHECK(numRowsAffected == 1);
+
+    CHECK(!dm.QuerySingle<Person>(person.id));
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "partial row retrieval", "[DataMapper]")
+{
+    auto dm = DataMapper();
+    dm.CreateTable<Person>();
+
+    auto person = Person {};
+    person.name = "John Doe";
+    person.is_active = true;
+    REQUIRE(person.id == 0);
+    dm.Create(person);
+
+    auto po = dm.QuerySingle<PersonName>(person.id);
+    auto p = po.value();
+    CHECK(p.name.Value() == person.name.Value());
+}
+
+struct RecordWithDefaults
+{
+    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<std::string> name1 { "John Doe" };
+    Field<std::optional<std::string>> name2 { "John Doe" };
+    Field<bool> boolean1 { true };
+    Field<bool> boolean2 { false };
+    Field<std::optional<int>> int1 { 42 };
+    Field<std::optional<int>> int2 {};
+};
+
+struct RecordWithNoDefaults
+{
+    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<std::string> name1;
+    Field<std::optional<std::string>> name2;
+    Field<bool> boolean1;
+    Field<bool> boolean2;
+    Field<std::optional<int>> int1;
+    Field<std::optional<int>> int2;
+
+    static constexpr std::string_view TableName = RecordTableName<RecordWithDefaults>;
+};
+
+TEST_CASE_METHOD(SqlTestFixture, "Create table with default values", "[DataMapper]")
+{
+    auto dm = DataMapper();
+    dm.CreateTable<RecordWithDefaults>();
+
+    auto record = RecordWithDefaults {};
+    dm.Create(record);
+
+    auto const actual = dm.QuerySingle<RecordWithNoDefaults>(record.id).value();
+    CHECK(actual.id == record.id);
+    CHECK(actual.name1 == record.name1);
+    CHECK(actual.boolean1 == record.boolean1);
+    CHECK(actual.boolean2 == record.boolean2);
+    CHECK(actual.int1 == record.int1);
+    CHECK(actual.int2 == record.int2);
+}
+
+// =========================================================================================================
+
+struct User;
+struct Email;
+
+struct User
+{
+    Field<int, PrimaryKey::AutoIncrement> id {};
+    Field<std::string> name {};
+
+    HasMany<Email> emails {};
+};
+
+struct Email
+{
+    Field<int, PrimaryKey::AutoIncrement> id {};
+    Field<std::string> address {};
+    BelongsTo<&User::id> user {};
+
+    constexpr std::weak_ordering operator<=>(Email const& other) const = default;
+};
+
+static_assert(RecordStorageFieldCount<User> == 2);
+static_assert(RecordStorageFieldCount<Email> == 3);
+
+std::ostream& operator<<(std::ostream& os, User const& record)
+{
+    return os << DataMapper::Inspect(record);
+}
+
+std::ostream& operator<<(std::ostream& os, Email const& record)
+{
+    return os << DataMapper::Inspect(record);
+}
+
+// TODO: Get this to work
+// std::ostream& operator<<(std::ostream& os, RecordWithStorageFields auto const& record)
+// {
+//     return os << DataMapper::Inspect(record);
+// }
+
+TEST_CASE_METHOD(SqlTestFixture, "BelongsTo", "[DataMapper][relations]")
+{
+    auto dm = DataMapper();
+    dm.CreateTables<User, Email>();
+
+    auto user = User { .name = "John Doe" };
+    dm.Create(user);
+
+    auto email1 = Email { .address = "john@doe.com", .user = user };
+    dm.Create(email1);
+
+    dm.CreateExplicit(Email { .address = "john2@doe.com", .user = user });
+
+    auto actualEmail1 = dm.QuerySingle<Email>(email1.id).value();
+    CHECK(actualEmail1 == email1);
+    dm.ConfigureRelationAutoLoading(actualEmail1);
+
+    REQUIRE(!actualEmail1.user.IsLoaded());
+    CHECK(actualEmail1.user->id == user.id);
+    REQUIRE(actualEmail1.user.IsLoaded());
+    CHECK(actualEmail1.user->name == user.name);
+
+    actualEmail1.user.Unload();
+    REQUIRE(!actualEmail1.user.IsLoaded());
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "HasMany", "[DataMapper][relations]")
+{
+    auto dm = DataMapper();
+    dm.CreateTables<User, Email>();
+
+    // Create user John with 2 email addresses
+    auto johnDoe = User { .name = "John Doe" };
+    dm.Create(johnDoe);
+
+    auto email1 = Email { .address = "john@doe.com", .user = johnDoe };
+    dm.Create(email1);
+
+    auto email2 = Email { .address = "john2@doe.com", .user = johnDoe };
+    dm.Create(email2);
+
+    // Create some other users
+    auto const janeDoeID = dm.CreateExplicit(User { .name = "Jane Doe" });
+    dm.CreateExplicit(Email { .address = "john3@doe.com", .user = janeDoeID.value });
+    auto const jimDoeID = dm.CreateExplicit(User { .name = "Jim Doe" });
+    dm.CreateExplicit(Email { .address = "john3@doe.com", .user = jimDoeID.value });
+
+    SECTION("Count")
+    {
+        REQUIRE(johnDoe.emails.Count() == 2);
+    }
+
+    SECTION("At")
+    {
+        CHECK(johnDoe.emails.At(0) == email1);
+        CHECK(johnDoe.emails.At(1) == email2);
+    }
+
+    SECTION("Each")
+    {
+        auto collectedEmails = std::vector<Email> {};
+        johnDoe.emails.Each([&](Email const& email) {
+            INFO("Email: " << DataMapper::Inspect(email));
+            collectedEmails.emplace_back(email);
+        });
+        CHECK(collectedEmails.size() == 2);
+        CHECK(collectedEmails.at(0) == email1);
+        CHECK(collectedEmails.at(1) == email2);
+    }
+}
+
+struct Suppliers;
+struct Account;
+struct AccountHistory;
+
+struct Suppliers
+{
+    Field<int, PrimaryKey::AutoIncrement> id {};
+    Field<std::string> name {};
+
+    // TODO: HasOne<Account> account;
+    HasOneThrough<AccountHistory, Account> accountHistory {};
+};
+
+std::ostream& operator<<(std::ostream& os, Suppliers const& record)
+{
+    return os << DataMapper::Inspect(record);
+}
+
+struct Account
+{
+    Field<int, PrimaryKey::AutoIncrement> id {};
+    Field<std::string> iban {};
+    BelongsTo<&Suppliers::id> supplier {};
+
+    constexpr std::weak_ordering operator<=>(Account const& other) const = default;
+};
+
+std::ostream& operator<<(std::ostream& os, Account const& record)
+{
+    return os << DataMapper::Inspect(record);
+}
+
+struct AccountHistory
+{
+    Field<int, PrimaryKey::AutoIncrement> id {};
+    Field<int> credit_rating {};
+    BelongsTo<&Account::id> account {};
+
+    constexpr std::weak_ordering operator<=>(AccountHistory const& other) const = default;
+};
+
+std::ostream& operator<<(std::ostream& os, AccountHistory const& record)
+{
+    return os << DataMapper::Inspect(record);
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "HasOneThrough", "[DataMapper][relations]")
+{
+    auto dm = DataMapper();
+    dm.CreateTables<Suppliers, Account, AccountHistory>();
+
+    auto supplier1 = Suppliers { .name = "Supplier 1" };
+    dm.Create(supplier1);
+
+    auto account1 = Account { .iban = "DE89370400440532013000", .supplier = supplier1 };
+    dm.Create(account1);
+
+    auto accountHistory1 = AccountHistory { .credit_rating = 100, .account = account1 };
+    dm.Create(accountHistory1);
+
+    SECTION("Explicit loading")
+    {
+        REQUIRE(!supplier1.accountHistory.IsLoaded());
+        dm.LoadRelations(supplier1);
+        REQUIRE(supplier1.accountHistory.IsLoaded());
+
+        CHECK(supplier1.accountHistory.Record() == accountHistory1);
+    }
+
+    SECTION("Auto loading")
+    {
+        dm.ConfigureRelationAutoLoading(supplier1);
+
+        REQUIRE(!supplier1.accountHistory.IsLoaded());
+        CHECK(supplier1.accountHistory.Record() == accountHistory1);
+        REQUIRE(supplier1.accountHistory.IsLoaded());
+    }
+}
+
+struct Physician;
+struct Appointment;
+struct Patient;
+
+struct Physician
+{
+    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<std::string> name;
+    HasMany<Appointment> appointments;
+    HasManyThrough<Patient, Appointment> patients;
+};
+
+struct Patient
+{
+    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<std::string> name;
+    Field<std::string> comment;
+    HasMany<Appointment> appointments;
+    HasManyThrough<Physician, Appointment> physicians;
+};
+
+struct Appointment
+{
+    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<SqlDateTime> date;
+    Field<std::string> comment;
+    BelongsTo<&Physician::id> physician;
+    BelongsTo<&Patient::id> patient;
+};
+
+TEST_CASE_METHOD(SqlTestFixture, "HasManyThrough", "[DataMapper][relations]")
+{
+    auto dm = DataMapper {};
+
+    dm.CreateTables<Physician, Patient, Appointment>();
+
+    Physician physician1;
+    physician1.name = "Dr. House";
+    dm.Create(physician1);
+
+    Physician physician2;
+    physician2.name = "Granny";
+    dm.Create(physician2);
+
+    Patient patient1;
+    patient1.name = "Blooper";
+    patient1.comment = "Prefers morning times";
+    dm.Create(patient1);
+
+    Patient patient2;
+    patient2.name = "Valentine";
+    patient2.comment = "always friendly";
+    dm.Create(patient2);
+
+    Appointment patient1Apointment1;
+    patient1Apointment1.date = SqlDateTime::Now();
+    patient1Apointment1.patient = patient1;
+    patient1Apointment1.physician = physician2;
+    patient1Apointment1.comment = "Patient is a bit nervous";
+    dm.Create(patient1Apointment1);
+
+    Appointment patient1Apointment2;
+    patient1Apointment2.date = SqlDateTime::Now();
+    patient1Apointment2.patient = patient1;
+    patient1Apointment2.physician = physician1;
+    patient1Apointment2.comment = "Patient is a bit nervous, again";
+    dm.Create(patient1Apointment2);
+
+    Appointment patient2Apointment1;
+    patient2Apointment1.date = SqlDateTime::Now();
+    patient2Apointment1.patient = patient2;
+    patient2Apointment1.physician = physician1;
+    patient2Apointment1.comment = "Patient is funny";
+    dm.Create(patient2Apointment1);
+
+    auto const queriedCount = physician1.patients.Count();
+    REQUIRE(queriedCount == 2);
+    CHECK(DataMapper::Inspect(physician1.patients.At(0)) == DataMapper::Inspect(patient1));
+    CHECK(DataMapper::Inspect(physician1.patients.At(1)) == DataMapper::Inspect(patient2));
+
+    CHECK(patient1.physicians.Count() == 2);
+    CHECK(DataMapper::Inspect(patient1.physicians.At(0)) == DataMapper::Inspect(physician2));
+    CHECK(DataMapper::Inspect(patient1.physicians.At(1)) == DataMapper::Inspect(physician1));
+
+    CHECK(patient2.physicians.Count() == 1);
+    CHECK(DataMapper::Inspect(patient2.physicians.At(0)) == DataMapper::Inspect(physician1));
+
+    // Test Each() method
+    size_t numPatientsIterated = 0;
+    std::vector<Patient> retrievedPatients;
+    physician2.patients.Each([&](Patient const& patient) {
+        REQUIRE(numPatientsIterated == 0);
+        ++numPatientsIterated;
+        std::println("Patient: {}", DataMapper::Inspect(patient));
+        retrievedPatients.emplace_back(patient);
+
+        // Load the relations of the patient
+        dm.ConfigureRelationAutoLoading(retrievedPatients.back());
+    });
+
+    Patient const& patient = retrievedPatients.at(0);
+    CHECK(DataMapper::Inspect(patient) == DataMapper::Inspect(patient1)); // Blooper
+    CHECK(patient.comment.Value() == "Prefers morning times");
+    CHECK(patient.physicians.Count() == 2);
+    CHECK(patient.physicians.At(0).name.Value() == "Granny");
+    CHECK(DataMapper::Inspect(patient.physicians.At(0)) == DataMapper::Inspect(physician2));
+}
+
+struct TestRecord
+{
+    Field<int, PrimaryKey::Manual> id {};
+    Field<std::string> comment;
+
+    std::weak_ordering operator<=>(TestRecord const& other) const = default;
+};
+
+std::ostream& operator<<(std::ostream& os, TestRecord const& record)
+{
+    return os << DataMapper::Inspect(record);
+}
+
+TEST_CASE_METHOD(SqlTestFixture, "manual primary key", "[DataMapper]")
+{
+    auto dm = DataMapper();
+    dm.CreateTable<TestRecord>();
+
+    auto record = TestRecord { .comment = "Hello, World!" };
+    dm.Create(record);
+    INFO("Created record: " << DataMapper::Inspect(record));
+    auto const queriedRecord = dm.QuerySingle<TestRecord>(record.id).value();
+    REQUIRE(queriedRecord == record);
+
+    auto record2 = TestRecord { .comment = "Hello, World! 2" };
+    dm.Create(record2);
+    INFO("Created record: " << DataMapper::Inspect(record2));
+    auto const queriedRecord2 = dm.QuerySingle<TestRecord>(record2.id).value();
+    REQUIRE(queriedRecord2 == record2);
+
+    REQUIRE(record.id != record2.id);
+}


### PR DESCRIPTION
**WIP**

Closes #25, #35, #42, #47

## Checklist

- [x] proper dependency integration of [reflection-cpp](https://github.com/contour-terminal/reflection-cpp)
- [x] #25
- [x] #35
- [ ] ~#42~
- [x] support primary key columns without auto-increment to be auto-filled
- [x] #47
- [x] (License adaption to Apache-2?)
- [x] `Field` refactor
- [ ] ~DataMapper: CreateTable() to take struct member default value into account for SQL default values~
- [x] DataMapper: `Create(Record&)`
- [x] DataMapper: `QuerySingle<Record>(primaryKeys...)`
- [x] DataMapper: `Update(Record&)`
- [x] DataMapper: `Delete(Record const&)`
- [x] association: `BelongsTo<>`
- [x] association: `HasMany<>`
- [x] association: `HasOneThrough<>`
- [x] association: `HasManyThrough<>`
- [x] on-demand loading for `BelongsTo<>`
- [x] on-demand loading for `HasMany<>`
- [x] on-demand loading for `HasOneThrough<>`
- [x] on-demand loading for `HasManyThrough<>`
- [x] resource-efficient traversal via `HasMany<>::Each(...)`
- [x] resource-efficient traversal via `HasManyThrough<>::Each(...)`
- [x] test cases adapted
