### PR TITLE
Unify DataBinder<> tests and fix some findings along the way

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,7 +250,7 @@ jobs:
           echo "ODBC_CONNECTION_STRING=${{ steps.setup.outputs.ODBC_CONNECTION_STRING }}"
           ldd /home/runner/oracle/instantclient_21_3/libsqora.so.21.1
       - name: "Run SQL Core tests"
-        run: LightweightTest --trace-odbc --trace-sql -s # --odbc-connection-string="${{ steps.setup.outputs.ODBC_CONNECTION_STRING }}"
+        run: LightweightTest # --odbc-connection-string="${{ steps.setup.outputs.ODBC_CONNECTION_STRING }}"
         env:
           ODBC_CONNECTION_STRING: "${{ steps.setup.outputs.ODBC_CONNECTION_STRING }}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
         compiler:
           [
             "GCC 14",
-            "Clang 18",
+            "Clang 19",
           ]
     name: "Ubuntu Linux 24.04 (${{ matrix.compiler }}, C++${{ matrix.cxx }})"
     runs-on: ubuntu-24.04
@@ -144,7 +144,14 @@ jobs:
         run: sudo apt install -y g++-${{ steps.extract_matrix.outputs.CC_VERSION }}
       - name: Install Clang
         if: ${{ startsWith(matrix.compiler, 'Clang') }}
-        run: sudo apt install -y clang-${{ steps.extract_matrix.outputs.CC_VERSION }} #libc++-dev libc++abi-dev
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh ${{ steps.extract_matrix.outputs.CC_VERSION }}
+          # What about: libc++-dev libc++abi-dev
+          sudo apt-get install -y \
+                        clang-format-${{ steps.extract_matrix.outputs.CC_VERSION }} \
+                        clang-${{ steps.extract_matrix.outputs.CC_VERSION }}
       - name: "cmake"
         run: |
           CC_NAME=$(echo "${{ matrix.compiler }}" | awk '{ print tolower($1); }')

--- a/.vimspector.json
+++ b/.vimspector.json
@@ -50,7 +50,7 @@
                     "uncaught": "Y"
                 }
             }
-        }
+        },
         "CoreTest - Postgres": {
             "adapter": "vscode-cpptools",
             "configuration": {

--- a/src/Lightweight/DataBinder/SqlDate.hpp
+++ b/src/Lightweight/DataBinder/SqlDate.hpp
@@ -11,35 +11,35 @@ struct LIGHTWEIGHT_API SqlDate
 {
     SQL_DATE_STRUCT sqlValue {};
 
-    SqlDate() noexcept = default;
-    SqlDate(SqlDate&&) noexcept = default;
-    SqlDate& operator=(SqlDate&&) noexcept = default;
-    SqlDate(SqlDate const&) noexcept = default;
-    SqlDate& operator=(SqlDate const&) noexcept = default;
-    ~SqlDate() noexcept = default;
+    constexpr SqlDate() noexcept = default;
+    constexpr SqlDate(SqlDate&&) noexcept = default;
+    constexpr SqlDate& operator=(SqlDate&&) noexcept = default;
+    constexpr SqlDate(SqlDate const&) noexcept = default;
+    constexpr SqlDate& operator=(SqlDate const&) noexcept = default;
+    constexpr ~SqlDate() noexcept = default;
 
-    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE std::chrono::year_month_day value() const noexcept
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr std::chrono::year_month_day value() const noexcept
     {
         return ConvertToNative(sqlValue);
     }
 
-    LIGHTWEIGHT_FORCE_INLINE bool operator==(SqlDate const& other) const noexcept
+    LIGHTWEIGHT_FORCE_INLINE constexpr bool operator==(SqlDate const& other) const noexcept
     {
         return sqlValue.year == other.sqlValue.year && sqlValue.month == other.sqlValue.month
                && sqlValue.day == other.sqlValue.day;
     }
 
-    LIGHTWEIGHT_FORCE_INLINE bool operator!=(SqlDate const& other) const noexcept
+    LIGHTWEIGHT_FORCE_INLINE constexpr bool operator!=(SqlDate const& other) const noexcept
     {
         return !(*this == other);
     }
 
-    SqlDate(std::chrono::year_month_day value) noexcept:
+    constexpr SqlDate(std::chrono::year_month_day value) noexcept:
         sqlValue { SqlDate::ConvertToSqlValue(value) }
     {
     }
 
-    SqlDate(std::chrono::year year, std::chrono::month month, std::chrono::day day) noexcept:
+    constexpr SqlDate(std::chrono::year year, std::chrono::month month, std::chrono::day day) noexcept:
         SqlDate(std::chrono::year_month_day { year, month, day })
     {
     }
@@ -51,7 +51,7 @@ struct LIGHTWEIGHT_API SqlDate
         } };
     }
 
-    static LIGHTWEIGHT_FORCE_INLINE SQL_DATE_STRUCT ConvertToSqlValue(std::chrono::year_month_day value) noexcept
+    static LIGHTWEIGHT_FORCE_INLINE constexpr SQL_DATE_STRUCT ConvertToSqlValue(std::chrono::year_month_day value) noexcept
     {
         return SQL_DATE_STRUCT {
             .year = (SQLSMALLINT) (int) value.year(),
@@ -60,7 +60,7 @@ struct LIGHTWEIGHT_API SqlDate
         };
     }
 
-    static LIGHTWEIGHT_FORCE_INLINE std::chrono::year_month_day ConvertToNative(SQL_DATE_STRUCT const& value) noexcept
+    static LIGHTWEIGHT_FORCE_INLINE constexpr std::chrono::year_month_day ConvertToNative(SQL_DATE_STRUCT const& value) noexcept
     {
         return std::chrono::year_month_day { std::chrono::year { value.year },
                                              std::chrono::month { static_cast<unsigned>(value.month) },

--- a/src/Lightweight/DataBinder/SqlDateTime.hpp
+++ b/src/Lightweight/DataBinder/SqlDateTime.hpp
@@ -15,24 +15,25 @@ struct LIGHTWEIGHT_API SqlDateTime
         return SqlDateTime { std::chrono::system_clock::now() };
     }
 
-    SqlDateTime() noexcept = default;
-    SqlDateTime(SqlDateTime&&) noexcept = default;
-    SqlDateTime& operator=(SqlDateTime&&) noexcept = default;
-    SqlDateTime(SqlDateTime const&) noexcept = default;
-    SqlDateTime& operator=(SqlDateTime const& other) noexcept = default;
-    ~SqlDateTime() noexcept = default;
+    constexpr SqlDateTime() noexcept = default;
+    constexpr SqlDateTime(SqlDateTime&&) noexcept = default;
+    constexpr SqlDateTime& operator=(SqlDateTime&&) noexcept = default;
+    constexpr SqlDateTime(SqlDateTime const&) noexcept = default;
+    constexpr SqlDateTime& operator=(SqlDateTime const& other) noexcept = default;
+    constexpr ~SqlDateTime() noexcept = default;
 
-    bool operator==(SqlDateTime const& other) const noexcept
+    constexpr bool operator==(SqlDateTime const& other) const noexcept
     {
         return value() == other.value();
     }
 
-    bool operator!=(SqlDateTime const& other) const noexcept
+    constexpr bool operator!=(SqlDateTime const& other) const noexcept
     {
         return !(*this == other);
     }
 
-    SqlDateTime(std::chrono::year_month_day ymd, std::chrono::hh_mm_ss<std::chrono::nanoseconds> time) noexcept
+    constexpr SqlDateTime(std::chrono::year_month_day ymd,
+                          std::chrono::hh_mm_ss<std::chrono::nanoseconds> time) noexcept
     {
         sqlValue.year = (SQLSMALLINT) (int) ymd.year();
         sqlValue.month = (SQLUSMALLINT) (unsigned) ymd.month();
@@ -43,13 +44,13 @@ struct LIGHTWEIGHT_API SqlDateTime
         sqlValue.fraction = (SQLUINTEGER) (time.subseconds().count() / 100) * 100;
     }
 
-    SqlDateTime(std::chrono::year year,
-                std::chrono::month month,
-                std::chrono::day day,
-                std::chrono::hours hour,
-                std::chrono::minutes minute,
-                std::chrono::seconds second,
-                std::chrono::nanoseconds nanosecond = std::chrono::nanoseconds { 0 }) noexcept
+    constexpr SqlDateTime(std::chrono::year year,
+                          std::chrono::month month,
+                          std::chrono::day day,
+                          std::chrono::hours hour,
+                          std::chrono::minutes minute,
+                          std::chrono::seconds second,
+                          std::chrono::nanoseconds nanosecond = std::chrono::nanoseconds { 0 }) noexcept
     {
         sqlValue.year = (SQLSMALLINT) (int) year;
         sqlValue.month = (SQLUSMALLINT) (unsigned) month;
@@ -60,17 +61,17 @@ struct LIGHTWEIGHT_API SqlDateTime
         sqlValue.fraction = (SQLUINTEGER) (nanosecond.count() / 100) * 100;
     }
 
-    SqlDateTime(std::chrono::system_clock::time_point value) noexcept:
+    constexpr SqlDateTime(std::chrono::system_clock::time_point value) noexcept:
         sqlValue { SqlDateTime::ConvertToSqlValue(value) }
     {
     }
 
-    operator native_type() const noexcept
+    constexpr operator native_type() const noexcept
     {
         return value();
     }
 
-    static SQL_TIMESTAMP_STRUCT ConvertToSqlValue(native_type value) noexcept
+    static SQL_TIMESTAMP_STRUCT constexpr ConvertToSqlValue(native_type value) noexcept
     {
         using namespace std::chrono;
         auto const totalDays = floor<days>(value);
@@ -88,7 +89,7 @@ struct LIGHTWEIGHT_API SqlDateTime
         };
     }
 
-    static native_type ConvertToNative(SQL_TIMESTAMP_STRUCT const& time) noexcept
+    static native_type constexpr ConvertToNative(SQL_TIMESTAMP_STRUCT const& time) noexcept
     {
         // clang-format off
         using namespace std::chrono;
@@ -101,7 +102,7 @@ struct LIGHTWEIGHT_API SqlDateTime
         // clang-format on
     }
 
-    [[nodiscard]] native_type value() const noexcept
+    [[nodiscard]] constexpr native_type value() const noexcept
     {
         return ConvertToNative(sqlValue);
     }

--- a/src/Lightweight/DataBinder/SqlTime.hpp
+++ b/src/Lightweight/DataBinder/SqlTime.hpp
@@ -44,42 +44,42 @@ struct SqlTime
 
     sql_type sqlValue {};
 
-    SqlTime() noexcept = default;
-    SqlTime(SqlTime&&) noexcept = default;
-    SqlTime& operator=(SqlTime&&) noexcept = default;
-    SqlTime(SqlTime const&) noexcept = default;
-    SqlTime& operator=(SqlTime const&) noexcept = default;
-    ~SqlTime() noexcept = default;
+    constexpr SqlTime() noexcept = default;
+    constexpr SqlTime(SqlTime&&) noexcept = default;
+    constexpr SqlTime& operator=(SqlTime&&) noexcept = default;
+    constexpr SqlTime(SqlTime const&) noexcept = default;
+    constexpr SqlTime& operator=(SqlTime const&) noexcept = default;
+    constexpr ~SqlTime() noexcept = default;
 
-    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE native_type value() const noexcept
+    [[nodiscard]] LIGHTWEIGHT_FORCE_INLINE constexpr native_type value() const noexcept
     {
         return ConvertToNative(sqlValue);
     }
 
-    LIGHTWEIGHT_FORCE_INLINE bool operator==(SqlTime const& other) const noexcept
+    LIGHTWEIGHT_FORCE_INLINE constexpr bool operator==(SqlTime const& other) const noexcept
     {
         return value().to_duration().count() == other.value().to_duration().count();
     }
 
-    LIGHTWEIGHT_FORCE_INLINE bool operator!=(SqlTime const& other) const noexcept
+    LIGHTWEIGHT_FORCE_INLINE constexpr bool operator!=(SqlTime const& other) const noexcept
     {
         return !(*this == other);
     }
 
-    LIGHTWEIGHT_FORCE_INLINE SqlTime(native_type value) noexcept:
+    LIGHTWEIGHT_FORCE_INLINE constexpr SqlTime(native_type value) noexcept:
         sqlValue { SqlTime::ConvertToSqlValue(value) }
     {
     }
 
-    LIGHTWEIGHT_FORCE_INLINE SqlTime(std::chrono::hours hour,
-                                     std::chrono::minutes minute,
-                                     std::chrono::seconds second,
-                                     std::chrono::microseconds micros = {}) noexcept:
+    LIGHTWEIGHT_FORCE_INLINE constexpr SqlTime(std::chrono::hours hour,
+                                               std::chrono::minutes minute,
+                                               std::chrono::seconds second,
+                                               std::chrono::microseconds micros = {}) noexcept:
         SqlTime(native_type { hour + minute + second + micros })
     {
     }
 
-    static LIGHTWEIGHT_FORCE_INLINE sql_type ConvertToSqlValue(native_type value) noexcept
+    static LIGHTWEIGHT_FORCE_INLINE constexpr sql_type ConvertToSqlValue(native_type value) noexcept
     {
         return sql_type {
             .hour = (SQLUSMALLINT) value.hours().count(),
@@ -91,7 +91,7 @@ struct SqlTime
         };
     }
 
-    static LIGHTWEIGHT_FORCE_INLINE native_type ConvertToNative(sql_type const& value) noexcept
+    static LIGHTWEIGHT_FORCE_INLINE constexpr native_type ConvertToNative(sql_type const& value) noexcept
     {
         // clang-format off
         return native_type { std::chrono::hours { (int) value.hour }

--- a/src/Lightweight/DataBinder/SqlTrimmedString.hpp
+++ b/src/Lightweight/DataBinder/SqlTrimmedString.hpp
@@ -42,6 +42,8 @@ struct SqlDataBinder<SqlTrimmedString>
 
     static void TrimRight(InnerStringType* boundOutputString, SQLLEN indicator) noexcept
     {
+        if (indicator < 0) // e.g. SQL_NULL_DATA
+            return;
         size_t n = indicator;
         while (n > 0 && std::isspace((*boundOutputString)[n - 1]))
             --n;

--- a/src/tests/CoreTests.cpp
+++ b/src/tests/CoreTests.cpp
@@ -44,9 +44,9 @@ TEST_CASE_METHOD(SqlTestFixture, "select: get columns")
 {
     auto stmt = SqlStatement {};
     stmt.ExecuteDirect("SELECT 42");
-    REQUIRE(stmt.FetchRow());
+    (void) stmt.FetchRow();
     REQUIRE(stmt.GetColumn<int>(1) == 42);
-    REQUIRE(!stmt.FetchRow());
+    (void) stmt.FetchRow();
 }
 
 TEST_CASE_METHOD(SqlTestFixture, "move semantics", "[SqlConnection]")
@@ -95,12 +95,12 @@ TEST_CASE_METHOD(SqlTestFixture, "select: get column (invalid index)")
 {
     auto stmt = SqlStatement {};
     stmt.ExecuteDirect("SELECT 42");
-    REQUIRE(stmt.FetchRow());
+    (void) stmt.FetchRow();
 
     auto const _ = ScopedSqlNullLogger {}; // suppress the error message, we are testing for it
 
     CHECK_THROWS_AS(stmt.GetColumn<int>(2), std::invalid_argument);
-    REQUIRE(!stmt.FetchRow());
+    (void) stmt.FetchRow();
 }
 
 TEST_CASE_METHOD(SqlTestFixture, "execute bound parameters and select back: VARCHAR, INT")
@@ -115,7 +115,7 @@ TEST_CASE_METHOD(SqlTestFixture, "execute bound parameters and select back: VARC
 
     stmt.ExecuteDirect("SELECT COUNT(*) FROM Employees");
     REQUIRE(stmt.NumColumnsAffected() == 1);
-    REQUIRE(stmt.FetchRow());
+    (void) stmt.FetchRow();
     REQUIRE(stmt.GetColumn<int>(1) == 3);
     REQUIRE(!stmt.FetchRow());
 
@@ -123,12 +123,12 @@ TEST_CASE_METHOD(SqlTestFixture, "execute bound parameters and select back: VARC
     REQUIRE(stmt.NumColumnsAffected() == 3);
     stmt.Execute(55'000);
 
-    REQUIRE(stmt.FetchRow());
+    (void) stmt.FetchRow();
     REQUIRE(stmt.GetColumn<std::string>(1) == "Bob");
     REQUIRE(stmt.GetColumn<std::string>(2) == "Johnson");
     REQUIRE(stmt.GetColumn<int>(3) == 60'000);
 
-    REQUIRE(stmt.FetchRow());
+    (void) stmt.FetchRow();
     REQUIRE(stmt.GetColumn<std::string>(1) == "Charlie");
     REQUIRE(stmt.GetColumn<std::string>(2) == "Brown");
     REQUIRE(stmt.GetColumn<int>(3) == 70'000);
@@ -152,7 +152,7 @@ TEST_CASE_METHOD(SqlTestFixture, "transaction: auto-rollback")
 
     REQUIRE(!stmt.Connection().TransactionActive());
     stmt.ExecuteDirect("SELECT COUNT(*) FROM Employees");
-    REQUIRE(stmt.FetchRow());
+    (void) stmt.FetchRow();
     REQUIRE(stmt.GetColumn<int>(1) == 0);
 }
 
@@ -172,7 +172,7 @@ TEST_CASE_METHOD(SqlTestFixture, "transaction: auto-commit")
 
     REQUIRE(!stmt.Connection().TransactionActive());
     stmt.ExecuteDirect("SELECT COUNT(*) FROM Employees");
-    REQUIRE(stmt.FetchRow());
+    (void) stmt.FetchRow();
     REQUIRE(stmt.GetColumn<int>(1) == 1);
 }
 
@@ -190,7 +190,7 @@ TEST_CASE_METHOD(SqlTestFixture, "execute binding output parameters (direct)")
     stmt.BindOutputColumns(&firstName, &lastName, &salary);
     stmt.Execute(50'000);
 
-    REQUIRE(stmt.FetchRow());
+    (void) stmt.FetchRow();
     CHECK(firstName == "Alice");
     CHECK(lastName == "Smith");
     CHECK(salary == 50'000);


### PR DESCRIPTION
- rework data binder tests to templated parametrized a test case
- and add checks for types `float` and `double`
- make some more SQL column types `constexpr`
- SqlFixedString: refactor null terminator handling
- SqlNumeric: Fix sending/retrieval for Oracle SQL server
- SqlTrimmedString: Fix right-trimming NULL values
- SqlStatement: Fix GetColumn() handling of nullable T's
- SqlNumeric: Add **explicit** native type cast operator overload
- more minors
- tests: perform sql trace logging through catch2's UNSCOPED_INFO
