### PR TITLE
Rename ExecuteDirectSingle() to ExecuteDirectScalar() to avoid confusion with QuerySingle()

### DIFF
--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -401,7 +401,7 @@ RecordId DataMapper::Create(Record& record)
             using ValueType = typename PrimaryKeyType::ValueType;
             if (primaryKeyField.Value() == ValueType {})
             {
-                auto maxId = SqlStatement { _connection }.ExecuteDirectSingle<ValueType>(
+                auto maxId = SqlStatement { _connection }.ExecuteDirectScalar<ValueType>(
                     std::format(R"sql(SELECT MAX("{}") FROM "{}")sql",
                                 FieldNameOf<PrimaryKeyIndex, Record>(),
                                 RecordTableName<Record>));

--- a/src/Lightweight/SqlStatement.cpp
+++ b/src/Lightweight/SqlStatement.cpp
@@ -172,7 +172,7 @@ size_t SqlStatement::NumColumnsAffected() const
 // Retrieves the last insert ID of the last query's primary key.
 size_t SqlStatement::LastInsertId()
 {
-    return ExecuteDirectSingle<size_t>(m_connection->Traits().LastInsertIdQuery).value_or(0);
+    return ExecuteDirectScalar<size_t>(m_connection->Traits().LastInsertIdQuery).value_or(0);
 }
 
 // Fetches the next row of the result set.

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -154,23 +154,23 @@ class SqlStatement final: public SqlDataBinderCallback
     // returned.
     template <typename T>
         requires(!std::same_as<T, SqlVariant>)
-    [[nodiscard]] std::optional<T> ExecuteDirectSingle(const std::string_view& query,
+    [[nodiscard]] std::optional<T> ExecuteDirectScalar(const std::string_view& query,
                                                        std::source_location location = std::source_location::current());
 
     template <typename T>
         requires(std::same_as<T, SqlVariant>)
-    [[nodiscard]] T ExecuteDirectSingle(const std::string_view& query,
+    [[nodiscard]] T ExecuteDirectScalar(const std::string_view& query,
                                         std::source_location location = std::source_location::current());
     // Executes the given query, assuming that only one result row and column is affected, that one will be
     // returned.
     template <typename T>
         requires(!std::same_as<T, SqlVariant>)
-    [[nodiscard]] std::optional<T> ExecuteDirectSingle(SqlQueryObject auto const& query,
+    [[nodiscard]] std::optional<T> ExecuteDirectScalar(SqlQueryObject auto const& query,
                                                        std::source_location location = std::source_location::current());
 
     template <typename T>
         requires(std::same_as<T, SqlVariant>)
-    [[nodiscard]] T ExecuteDirectSingle(SqlQueryObject auto const& query,
+    [[nodiscard]] T ExecuteDirectScalar(SqlQueryObject auto const& query,
                                         std::source_location location = std::source_location::current());
 
     // Retrieves the number of rows affected by the last query.
@@ -542,7 +542,7 @@ inline LIGHTWEIGHT_FORCE_INLINE void SqlStatement::ExecuteDirect(SqlQueryObject 
 
 template <typename T>
     requires(!std::same_as<T, SqlVariant>)
-inline LIGHTWEIGHT_FORCE_INLINE std::optional<T> SqlStatement::ExecuteDirectSingle(const std::string_view& query,
+inline LIGHTWEIGHT_FORCE_INLINE std::optional<T> SqlStatement::ExecuteDirectScalar(const std::string_view& query,
                                                                                    std::source_location location)
 {
     auto const _ = detail::Finally([this] { CloseCursor(); });
@@ -553,7 +553,7 @@ inline LIGHTWEIGHT_FORCE_INLINE std::optional<T> SqlStatement::ExecuteDirectSing
 
 template <typename T>
     requires(std::same_as<T, SqlVariant>)
-inline LIGHTWEIGHT_FORCE_INLINE T SqlStatement::ExecuteDirectSingle(const std::string_view& query,
+inline LIGHTWEIGHT_FORCE_INLINE T SqlStatement::ExecuteDirectScalar(const std::string_view& query,
                                                                     std::source_location location)
 {
     auto const _ = detail::Finally([this] { CloseCursor(); });
@@ -566,18 +566,18 @@ inline LIGHTWEIGHT_FORCE_INLINE T SqlStatement::ExecuteDirectSingle(const std::s
 
 template <typename T>
     requires(!std::same_as<T, SqlVariant>)
-inline LIGHTWEIGHT_FORCE_INLINE std::optional<T> SqlStatement::ExecuteDirectSingle(SqlQueryObject auto const& query,
+inline LIGHTWEIGHT_FORCE_INLINE std::optional<T> SqlStatement::ExecuteDirectScalar(SqlQueryObject auto const& query,
                                                                                    std::source_location location)
 {
-    return ExecuteDirectSingle<T>(query.ToSql(), location);
+    return ExecuteDirectScalar<T>(query.ToSql(), location);
 }
 
 template <typename T>
     requires(std::same_as<T, SqlVariant>)
-inline LIGHTWEIGHT_FORCE_INLINE T SqlStatement::ExecuteDirectSingle(SqlQueryObject auto const& query,
+inline LIGHTWEIGHT_FORCE_INLINE T SqlStatement::ExecuteDirectScalar(SqlQueryObject auto const& query,
                                                                     std::source_location location)
 {
-    return ExecuteDirectSingle<T>(query.ToSql(), location);
+    return ExecuteDirectScalar<T>(query.ToSql(), location);
 }
 
 inline LIGHTWEIGHT_FORCE_INLINE void SqlStatement::CloseCursor() noexcept

--- a/src/tests/CoreTests.cpp
+++ b/src/tests/CoreTests.cpp
@@ -69,7 +69,7 @@ TEST_CASE_METHOD(SqlTestFixture, "move semantics", "[SqlStatement]")
     auto conn = SqlConnection {};
 
     auto const TestRun = [](SqlStatement& stmt) {
-        CHECK(stmt.ExecuteDirectSingle<int>("SELECT 42").value_or(-1) == 42);
+        CHECK(stmt.ExecuteDirectScalar<int>("SELECT 42").value_or(-1) == 42);
     };
 
     auto a = SqlStatement { conn };

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -206,11 +206,11 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlVariant: NULL values", "[SqlDataBinder],[Sq
         CHECK(std::holds_alternative<SqlNullType>(actual.value));
     }
 
-    SECTION("Using ExecuteDirectSingle")
+    SECTION("Using ExecuteDirectScalar")
     {
         stmt.Prepare("INSERT INTO Test (Remarks) VALUES (?)");
         stmt.Execute(SqlNullValue);
-        auto const result = stmt.ExecuteDirectSingle<SqlVariant>("SELECT Remarks FROM Test");
+        auto const result = stmt.ExecuteDirectScalar<SqlVariant>("SELECT Remarks FROM Test");
         CHECK(result.IsNull());
     }
 }
@@ -238,7 +238,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlVariant: SqlDate", "[SqlDataBinder],[SqlVar
     stmt.ExecuteDirect("DELETE FROM Test");
     stmt.Prepare("INSERT INTO Test (Value) VALUES (?)");
     stmt.Execute(SqlNullValue);
-    auto const result = stmt.ExecuteDirectSingle<SqlVariant>("SELECT Value FROM Test");
+    auto const result = stmt.ExecuteDirectScalar<SqlVariant>("SELECT Value FROM Test");
     CHECK(result.IsNull());
 }
 
@@ -254,7 +254,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlVariant: SqlTime", "[SqlDataBinder],[SqlVar
     stmt.Prepare("INSERT INTO Test (Value) VALUES (?)");
     stmt.Execute(expected);
 
-    auto const actual = stmt.ExecuteDirectSingle<SqlVariant>("SELECT Value FROM Test");
+    auto const actual = stmt.ExecuteDirectScalar<SqlVariant>("SELECT Value FROM Test");
 
     if (stmt.Connection().ServerType() == SqlServerType::POSTGRESQL)
     {
@@ -269,7 +269,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlVariant: SqlTime", "[SqlDataBinder],[SqlVar
     stmt.ExecuteDirect("DELETE FROM Test");
     stmt.Prepare("INSERT INTO Test (Value) VALUES (?)");
     stmt.Execute(SqlNullValue);
-    auto const result = stmt.ExecuteDirectSingle<SqlVariant>("SELECT Value FROM Test");
+    auto const result = stmt.ExecuteDirectScalar<SqlVariant>("SELECT Value FROM Test");
     CHECK(result.IsNull());
 }
 
@@ -366,7 +366,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlDataBinder: Unicode", "[SqlDataBinder],[Uni
         stmt.ExecuteDirect("DELETE FROM Test");
         stmt.Prepare("INSERT INTO Test (Value) VALUES (?)");
         stmt.Execute(SqlNullValue);
-        auto const result = stmt.ExecuteDirectSingle<WideString>("SELECT Value FROM Test");
+        auto const result = stmt.ExecuteDirectScalar<WideString>("SELECT Value FROM Test");
         CHECK(!result.has_value());
     }
 }

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -379,7 +379,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder: sub select with Where", "[Sql
     auto const secrets = std::vector<int> { 42, 43, 44, 45 };
     stmt.ExecuteBatchSoft(names, secrets);
 
-    auto const totalRecords = stmt.ExecuteDirectSingle<int>(R"SQL(SELECT COUNT(*) FROM "Test")SQL");
+    auto const totalRecords = stmt.ExecuteDirectScalar<int>(R"SQL(SELECT COUNT(*) FROM "Test")SQL");
     REQUIRE(totalRecords.value_or(0) == 4);
 
     // clang-format off
@@ -421,7 +421,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder: sub select with WhereIn", "[S
     auto const secrets = std::vector<int> { 42, 43, 44, 45 };
     stmt.ExecuteBatchSoft(names, secrets);
 
-    auto const totalRecords = stmt.ExecuteDirectSingle<int>("SELECT COUNT(*) FROM \"Test\"");
+    auto const totalRecords = stmt.ExecuteDirectScalar<int>("SELECT COUNT(*) FROM \"Test\"");
     REQUIRE(totalRecords.value_or(0) == 4);
 
     // clang-format off


### PR DESCRIPTION
makes it also look similar to what Dapper is offering as API to query single column values from a single row.