### PR TITLE
Add input_iterator API wrapper over sql statement

### DIFF
--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -54,18 +54,6 @@ auto ToSharedPtrList(Container<Object, Allocator<Object>> container)
     return sharedPtrContainer;
 }
 
-template <typename Record>
-struct RecordTableName
-{
-    static constexpr std::string_view Value = []() {
-        if constexpr (requires { Record::TableName; })
-            return Record::TableName;
-        else
-            // TODO: Build plural
-            return Reflection::TypeName<Record>;
-    }();
-};
-
 } // namespace detail
 
 template <typename Record>

--- a/src/Lightweight/Utils.hpp
+++ b/src/Lightweight/Utils.hpp
@@ -35,6 +35,18 @@ struct MemberClassTypeHelper<M T::*>
     using type = std::remove_cvref_t<T>;
 };
 
+template <typename Record>
+struct RecordTableName
+{
+    static constexpr std::string_view Value = []() {
+        if constexpr (requires { Record::TableName; })
+            return Record::TableName;
+        else
+            // TODO: Build plural
+            return Reflection::TypeName<Record>;
+    }();
+};
+
 } // namespace detail
 
 template <template <typename...> class S, class T>

--- a/src/tests/DataMapperTests.cpp
+++ b/src/tests/DataMapperTests.cpp
@@ -111,6 +111,32 @@ TEST_CASE_METHOD(SqlTestFixture, "partial row retrieval", "[DataMapper]")
     CHECK(p.name.Value() == person.name.Value());
 }
 
+TEST_CASE_METHOD(SqlTestFixture, "iterate over database", "[SqlRowIterator]")
+{
+    auto dm = DataMapper();
+    dm.CreateTable<Person>();
+
+    for (int i = 40; i <= 50; ++i)
+    {
+        auto person = Person {};
+        person.name = "John";
+        person.age = i;
+        dm.Create(person);
+    }
+
+    auto stmt = SqlStatement { dm.Connection() };
+    int age = 40;
+    int id = 1;
+    for (auto&& person: SqlRowIterator<Person>(stmt))
+    {
+        CHECK(person.name.Value() == "John");
+        CHECK(person.age.Value() == age);
+        CHECK(person.id.Value() == id);
+        ++age;
+        ++id;
+    }
+}
+
 struct RecordWithDefaults
 {
     Field<uint64_t, PrimaryKey::AutoIncrement> id;


### PR DESCRIPTION
PR implements following use case:
```
struct movies final
{
    Field<int, PrimaryKey::Manual> movie_id;
    Field<SqlTrimmedFixedString<25>> movie_title;
};
```

```
auto stmt = SqlStatement {};
for(auto&& val: iterator<movies>(stmt, "movies"))
    std::println("{}{}", val.movie_id.Value(),val.movie_title.Value());
```