### PR TITLE
SQL Migration  query builder API and migration API

### DIFF
--- a/src/Lightweight/CMakeLists.txt
+++ b/src/Lightweight/CMakeLists.txt
@@ -42,6 +42,8 @@ set(HEADER_FILES
     SqlQuery/Core.hpp
     SqlQuery/Delete.hpp
     SqlQuery/Insert.hpp
+    SqlQuery/Migrate.hpp
+    SqlQuery/MigrationPlan.hpp
     SqlQuery/Select.hpp
     SqlQuery/Update.hpp
 
@@ -70,6 +72,8 @@ set(SOURCE_FILES
     SqlError.cpp
     SqlLogger.cpp
     SqlQuery.cpp
+    SqlQuery/Migrate.cpp
+    SqlQuery/MigrationPlan.cpp
     SqlQuery/Select.cpp
     SqlQueryFormatter.cpp
     SqlSchema.cpp

--- a/src/Lightweight/SqlConnection.cpp
+++ b/src/Lightweight/SqlConnection.cpp
@@ -321,3 +321,8 @@ SqlQueryBuilder SqlConnection::QueryAs(std::string_view const& table, std::strin
 {
     return SqlQueryBuilder(QueryFormatter(), std::string(table), std::string(tableAlias));
 }
+
+SqlMigrationQueryBuilder SqlConnection::Migration() const
+{
+    return SqlMigrationQueryBuilder(QueryFormatter());
+}

--- a/src/Lightweight/SqlConnection.hpp
+++ b/src/Lightweight/SqlConnection.hpp
@@ -29,6 +29,7 @@
 #include <sqltypes.h>
 
 class SqlQueryBuilder;
+class SqlMigrationQueryBuilder;
 class SqlQueryFormatter;
 
 // @brief Represents a connection to a SQL database.
@@ -108,11 +109,14 @@ class LIGHTWEIGHT_API SqlConnection final
     // Retrieves a query formatter suitable for the SQL server being connected.
     [[nodiscard]] SqlQueryFormatter const& QueryFormatter() const noexcept;
 
-    // Creates a new query builder for the given table, compatible with the SQL server being connected.
+    // Creates a new query builder for the given table, compatible with the current connection.
     [[nodiscard]] SqlQueryBuilder Query(std::string_view const& table = {}) const;
 
-    // Creates a new query builder for the given table with an alias, compatible with the SQL server being connected.
+    // Creates a new query builder for the given table with an alias, compatible with the current connection.
     [[nodiscard]] SqlQueryBuilder QueryAs(std::string_view const& table, std::string_view const& tableAlias) const;
+
+    // Creates a new migration query builder, compatible the current connection.
+    [[nodiscard]] SqlMigrationQueryBuilder Migration() const;
 
     // Retrieves the SQL traits for the server.
     [[nodiscard]] SqlTraits const& Traits() const noexcept

--- a/src/Lightweight/SqlQuery.cpp
+++ b/src/Lightweight/SqlQuery.cpp
@@ -34,3 +34,8 @@ SqlDeleteQueryBuilder SqlQueryBuilder::Delete() noexcept
 {
     return SqlDeleteQueryBuilder(m_formatter, std::move(m_table), std::move(m_tableAlias));
 }
+
+LIGHTWEIGHT_API SqlMigrationQueryBuilder SqlQueryBuilder::Migration()
+{
+    return SqlMigrationQueryBuilder(m_formatter);
+}

--- a/src/Lightweight/SqlQuery.hpp
+++ b/src/Lightweight/SqlQuery.hpp
@@ -4,6 +4,7 @@
 #include "Api.hpp"
 #include "SqlQuery/Delete.hpp"
 #include "SqlQuery/Insert.hpp"
+#include "SqlQuery/Migrate.hpp"
 #include "SqlQuery/Select.hpp"
 #include "SqlQuery/Update.hpp"
 
@@ -41,6 +42,8 @@ class [[nodiscard]] SqlQueryBuilder final
 
     // Initiates DELETE query building
     LIGHTWEIGHT_API SqlDeleteQueryBuilder Delete() noexcept;
+
+    LIGHTWEIGHT_API SqlMigrationQueryBuilder Migration();
 
   private:
     SqlQueryFormatter const& m_formatter;

--- a/src/Lightweight/SqlQuery/Migrate.cpp
+++ b/src/Lightweight/SqlQuery/Migrate.cpp
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "../SqlQueryFormatter.hpp"
+#include "Migrate.hpp"
+
+SqlMigrationPlan SqlMigrationQueryBuilder::GetPlan()
+{
+    return _migrationPlan;
+}
+
+SqlMigrationQueryBuilder& SqlMigrationQueryBuilder::DropTable(std::string_view tableName)
+{
+    _migrationPlan.steps.emplace_back(SqlDropTablePlan {
+        .tableName = tableName,
+    });
+    return *this;
+}
+
+SqlCreateTableQueryBuilder SqlMigrationQueryBuilder::CreateTable(std::string_view tableName)
+{
+    _migrationPlan.steps.emplace_back(SqlCreateTablePlan {
+        .tableName = tableName,
+        .columns = {},
+    });
+    return SqlCreateTableQueryBuilder { std::get<SqlCreateTablePlan>(_migrationPlan.steps.back()) };
+}
+
+SqlAlterTableQueryBuilder SqlMigrationQueryBuilder::AlterTable(std::string_view tableName)
+{
+    _migrationPlan.steps.emplace_back(SqlAlterTablePlan {
+        .tableName = tableName,
+        .commands = {},
+    });
+    return SqlAlterTableQueryBuilder { std::get<SqlAlterTablePlan>(_migrationPlan.steps.back()) };
+}
+
+SqlAlterTableQueryBuilder& SqlAlterTableQueryBuilder::RenameTo(std::string_view newTableName)
+{
+    _plan.commands.emplace_back(SqlAlterTableCommands::RenameTable {
+        .newTableName = newTableName,
+    });
+    return *this;
+}
+
+SqlAlterTableQueryBuilder& SqlAlterTableQueryBuilder::AddColumn(std::string_view columnName,
+                                                                SqlColumnTypeDefinition columnType)
+{
+    _plan.commands.emplace_back(SqlAlterTableCommands::AddColumn {
+        .columnName = columnName,
+        .columnType = columnType,
+    });
+    return *this;
+}
+
+SqlAlterTableQueryBuilder& SqlAlterTableQueryBuilder::RenameColumn(std::string_view oldColumnName,
+                                                                   std::string_view newColumnName)
+{
+    _plan.commands.emplace_back(SqlAlterTableCommands::RenameColumn {
+        .oldColumnName = oldColumnName,
+        .newColumnName = newColumnName,
+    });
+    return *this;
+}
+
+SqlAlterTableQueryBuilder& SqlAlterTableQueryBuilder::DropColumn(std::string_view columnName)
+{
+    _plan.commands.emplace_back(SqlAlterTableCommands::DropColumn {
+        .columnName = columnName,
+    });
+    return *this;
+}
+
+SqlAlterTableQueryBuilder& SqlAlterTableQueryBuilder::AddIndex(std::string_view columnName)
+{
+    _plan.commands.emplace_back(SqlAlterTableCommands::AddIndex {
+        .columnName = columnName,
+        .unique = false,
+    });
+    return *this;
+}
+
+SqlAlterTableQueryBuilder& SqlAlterTableQueryBuilder::AddUniqueIndex(std::string_view columnName)
+{
+    _plan.commands.emplace_back(SqlAlterTableCommands::AddIndex {
+        .columnName = columnName,
+        .unique = true,
+    });
+    return *this;
+}
+
+SqlAlterTableQueryBuilder& SqlAlterTableQueryBuilder::DropIndex(std::string_view columnName)
+{
+    _plan.commands.emplace_back(SqlAlterTableCommands::DropIndex {
+        .columnName = columnName,
+    });
+    return *this;
+}
+
+SqlCreateTableQueryBuilder& SqlCreateTableQueryBuilder::Column(SqlColumnDeclaration column)
+{
+    _plan.columns.emplace_back(std::move(column));
+    return *this;
+}
+
+SqlCreateTableQueryBuilder& SqlCreateTableQueryBuilder::Column(std::string columnName,
+                                                               SqlColumnTypeDefinition columnType)
+{
+    return Column(SqlColumnDeclaration {
+        .name = std::move(columnName),
+        .type = columnType,
+    });
+}
+
+SqlCreateTableQueryBuilder& SqlCreateTableQueryBuilder::RequiredColumn(std::string columnName,
+                                                                       SqlColumnTypeDefinition columnType)
+{
+    return Column(SqlColumnDeclaration {
+        .name = std::move(columnName),
+        .type = columnType,
+        .required = true,
+    });
+}
+
+SqlCreateTableQueryBuilder& SqlCreateTableQueryBuilder::PrimaryKey(std::string columnName,
+                                                                   SqlColumnTypeDefinition columnType)
+{
+    return Column(SqlColumnDeclaration {
+        .name = std::move(columnName),
+        .type = columnType,
+        .primaryKey = SqlPrimaryKeyType::MANUAL,
+        .required = true,
+        .unique = true,
+        .index = true,
+    });
+}
+
+SqlCreateTableQueryBuilder& SqlCreateTableQueryBuilder::PrimaryKeyWithAutoIncrement(std::string columnName,
+                                                                                    SqlColumnTypeDefinition columnType)
+{
+    return Column(SqlColumnDeclaration {
+        .name = std::move(columnName),
+        .type = columnType,
+        .primaryKey = SqlPrimaryKeyType::AUTO_INCREMENT,
+        .required = true,
+        .unique = true,
+        .index = true,
+    });
+}
+
+SqlCreateTableQueryBuilder& SqlCreateTableQueryBuilder::Unique()
+{
+    _plan.columns.back().unique = true;
+    return *this;
+}
+
+SqlCreateTableQueryBuilder& SqlCreateTableQueryBuilder::Index()
+{
+    _plan.columns.back().index = true;
+    return *this;
+}
+
+SqlCreateTableQueryBuilder& SqlCreateTableQueryBuilder::UniqueIndex()
+{
+    _plan.columns.back().index = true;
+    _plan.columns.back().unique = true;
+    return *this;
+}

--- a/src/Lightweight/SqlQuery/Migrate.hpp
+++ b/src/Lightweight/SqlQuery/Migrate.hpp
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "Core.hpp"
+#include "MigrationPlan.hpp"
+
+#include <reflection-cpp/reflection.hpp>
+
+class [[nodiscard]] SqlCreateTableQueryBuilder final
+{
+  public:
+    explicit SqlCreateTableQueryBuilder(SqlCreateTablePlan& plan):
+        _plan { plan }
+    {
+    }
+
+    // Adds a new column to the table.
+    LIGHTWEIGHT_API SqlCreateTableQueryBuilder& Column(SqlColumnDeclaration column);
+
+    // Creates a new nullable column.
+    LIGHTWEIGHT_API SqlCreateTableQueryBuilder& Column(std::string columnName, SqlColumnTypeDefinition columnType);
+
+    // Creates a new column that is non-nullable.
+    LIGHTWEIGHT_API SqlCreateTableQueryBuilder& RequiredColumn(std::string columnName,
+                                                               SqlColumnTypeDefinition columnType);
+
+    // Creates a new primary key column.
+    // Primary keys are always required, unique, have an index, and are non-nullable.
+    LIGHTWEIGHT_API SqlCreateTableQueryBuilder& PrimaryKey(std::string columnName, SqlColumnTypeDefinition columnType);
+
+    LIGHTWEIGHT_API SqlCreateTableQueryBuilder& PrimaryKeyWithAutoIncrement(
+        std::string columnName, SqlColumnTypeDefinition columnType = SqlColumnTypeDefinitions::Bigint {});
+
+    // Enables the UNIQUE constraint on the last declared column.
+    LIGHTWEIGHT_API SqlCreateTableQueryBuilder& Unique();
+
+    // Enables the UNIQUE constraint on the last declared column.
+    LIGHTWEIGHT_API SqlCreateTableQueryBuilder& Index();
+
+    // Enables the UNIQUE constraint on the last declared column and makes it an index.
+    LIGHTWEIGHT_API SqlCreateTableQueryBuilder& UniqueIndex();
+
+  private:
+    SqlCreateTablePlan& _plan;
+};
+
+class [[nodiscard]] SqlAlterTableQueryBuilder final
+{
+  public:
+    explicit SqlAlterTableQueryBuilder(SqlAlterTablePlan& plan):
+        _plan { plan }
+    {
+    }
+
+    // Renames the table.
+    LIGHTWEIGHT_API SqlAlterTableQueryBuilder& RenameTo(std::string_view newTableName);
+
+    // Adds a new column to the table that is non-nullable.
+    LIGHTWEIGHT_API SqlAlterTableQueryBuilder& AddColumn(std::string_view columnName,
+                                                         SqlColumnTypeDefinition columnType);
+
+    // Adds a new column to the table that is nullable.
+    LIGHTWEIGHT_API SqlAlterTableQueryBuilder& AddColumnAsNullable(std::string_view columnName,
+                                                                   SqlColumnTypeDefinition columnType);
+
+    // Alters the column to have a new non-nullable type.
+    LIGHTWEIGHT_API SqlAlterTableQueryBuilder& AlterColumn(std::string_view columnName,
+                                                           SqlColumnTypeDefinition columnType);
+
+    // Alters the column to have a new nullable type.
+    LIGHTWEIGHT_API SqlAlterTableQueryBuilder& AlterColumnAsNullable(std::string_view columnName,
+                                                                     SqlColumnTypeDefinition columnType);
+
+    LIGHTWEIGHT_API SqlAlterTableQueryBuilder& RenameColumn(std::string_view oldColumnName,
+                                                            std::string_view newColumnName);
+
+    LIGHTWEIGHT_API SqlAlterTableQueryBuilder& DropColumn(std::string_view columnName);
+
+    LIGHTWEIGHT_API SqlAlterTableQueryBuilder& AddIndex(std::string_view columnName);
+
+    LIGHTWEIGHT_API SqlAlterTableQueryBuilder& AddUniqueIndex(std::string_view columnName);
+
+    LIGHTWEIGHT_API SqlAlterTableQueryBuilder& DropIndex(std::string_view columnName);
+
+  private:
+    SqlAlterTablePlan& _plan;
+};
+
+class [[nodiscard]] SqlMigrationQueryBuilder final
+{
+  public:
+    explicit SqlMigrationQueryBuilder(SqlQueryFormatter const& formatter):
+        _formatter { formatter },
+        _migrationPlan { .formatter = formatter }
+    {
+    }
+
+    LIGHTWEIGHT_API SqlMigrationQueryBuilder& CreateDatabase(std::string_view databaseName);
+    LIGHTWEIGHT_API SqlMigrationQueryBuilder& DropDatabase(std::string_view databaseName);
+
+    LIGHTWEIGHT_API SqlCreateTableQueryBuilder CreateTable(std::string_view tableName);
+    LIGHTWEIGHT_API SqlAlterTableQueryBuilder AlterTable(std::string_view tableName);
+    LIGHTWEIGHT_API SqlMigrationQueryBuilder& DropTable(std::string_view tableName);
+
+    LIGHTWEIGHT_API SqlMigrationQueryBuilder& RawSql(std::string_view sql);
+    LIGHTWEIGHT_API SqlMigrationQueryBuilder& Native(std::function<std::string(SqlConnection&)> callback);
+
+    LIGHTWEIGHT_API SqlMigrationQueryBuilder& BeginTransaction();
+    LIGHTWEIGHT_API SqlMigrationQueryBuilder& CommitTransaction();
+
+    LIGHTWEIGHT_API SqlMigrationPlan GetPlan();
+
+  private:
+    SqlQueryFormatter const& _formatter;
+    SqlMigrationPlan _migrationPlan;
+};

--- a/src/Lightweight/SqlQuery/MigrationPlan.cpp
+++ b/src/Lightweight/SqlQuery/MigrationPlan.cpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "../SqlQueryFormatter.hpp"
+#include "MigrationPlan.hpp"
+
+std::string SqlMigrationPlan::ToSql() const
+{
+    std::string result;
+    for (auto const& step: steps)
+        result += ToSql(formatter, step);
+    return result;
+}
+
+std::string SqlMigrationPlan::ToSql(SqlQueryFormatter const& formatter, SqlMigrationPlanElement const& element)
+{
+    using namespace std::string_literals;
+    return std::visit(
+        [&](auto const& step) {
+            if constexpr (std::is_same_v<std::decay_t<decltype(step)>, SqlCreateTablePlan>)
+            {
+                return formatter.CreateTable(step.tableName, step.columns);
+            }
+            else if constexpr (std::is_same_v<std::decay_t<decltype(step)>, SqlAlterTablePlan>)
+            {
+                return formatter.AlterTable(step.tableName, step.commands);
+            }
+            else if constexpr (std::is_same_v<std::decay_t<decltype(step)>, SqlDropTablePlan>)
+            {
+                return formatter.DropTable(step.tableName);
+            }
+            else
+            {
+                static_assert(false, "non-exhaustive visitor");
+            }
+        },
+        element);
+}

--- a/src/Lightweight/SqlQuery/MigrationPlan.hpp
+++ b/src/Lightweight/SqlQuery/MigrationPlan.hpp
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "../Api.hpp"
+
+#include <reflection-cpp/reflection.hpp>
+
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+class SqlQueryFormatter;
+
+// clang-format off
+namespace SqlColumnTypeDefinitions
+{
+
+struct Bool {};
+struct Char { size_t size = 1; };
+struct Varchar { size_t size {}; };
+struct Text { size_t size {}; };
+struct Smallint {};
+struct Integer {};
+struct Bigint {};
+struct Real {};
+struct Decimal { size_t precision {}; size_t scale {}; };
+struct DateTime {};
+struct Timestamp {};
+struct Date {};
+struct Time {};
+struct Guid {};
+
+} // namespace SqlColumnTypeDefinitions
+
+using SqlColumnTypeDefinition = std::variant<
+    SqlColumnTypeDefinitions::Bigint,
+    SqlColumnTypeDefinitions::Bool,
+    SqlColumnTypeDefinitions::Char,
+    SqlColumnTypeDefinitions::Date,
+    SqlColumnTypeDefinitions::DateTime,
+    SqlColumnTypeDefinitions::Decimal,
+    SqlColumnTypeDefinitions::Guid,
+    SqlColumnTypeDefinitions::Integer,
+    SqlColumnTypeDefinitions::Real,
+    SqlColumnTypeDefinitions::Smallint,
+    SqlColumnTypeDefinitions::Text,
+    SqlColumnTypeDefinitions::Time,
+    SqlColumnTypeDefinitions::Timestamp,
+    SqlColumnTypeDefinitions::Varchar
+>;
+// clang-format on
+
+enum class SqlPrimaryKeyType : uint8_t
+{
+    NONE,
+    MANUAL,
+    AUTO_INCREMENT,
+    GUID,
+};
+
+struct SqlColumnDeclaration
+{
+    std::string name;
+    SqlColumnTypeDefinition type;
+    SqlPrimaryKeyType primaryKey { SqlPrimaryKeyType::NONE };
+    bool required { false };
+    bool unique { false };
+    bool index { false };
+};
+
+struct SqlCreateTablePlan
+{
+    std::string_view tableName;
+    std::vector<SqlColumnDeclaration> columns;
+};
+
+namespace SqlAlterTableCommands
+{
+
+struct RenameTable
+{
+    std::string_view newTableName;
+};
+
+struct AddColumn
+{
+    std::string_view columnName;
+    SqlColumnTypeDefinition columnType;
+};
+
+struct AddIndex
+{
+    std::string_view columnName;
+    bool unique = false;
+};
+
+struct RenameColumn
+{
+    std::string_view oldColumnName;
+    std::string_view newColumnName;
+};
+
+struct DropColumn
+{
+    std::string_view columnName;
+};
+
+struct DropIndex
+{
+    std::string_view columnName;
+};
+
+}; // namespace SqlAlterTableCommands
+
+using SqlAlterTableCommand = std::variant<SqlAlterTableCommands::RenameTable,
+                                          SqlAlterTableCommands::AddColumn,
+                                          SqlAlterTableCommands::AddIndex,
+                                          SqlAlterTableCommands::RenameColumn,
+                                          SqlAlterTableCommands::DropColumn,
+                                          SqlAlterTableCommands::DropIndex>;
+
+struct SqlAlterTablePlan
+{
+    std::string_view tableName;
+    std::vector<SqlAlterTableCommand> commands;
+};
+
+struct SqlDropTablePlan
+{
+    std::string_view tableName;
+};
+
+// clang-format off
+using SqlMigrationPlanElement = std::variant<
+    SqlCreateTablePlan,
+    SqlAlterTablePlan,
+    SqlDropTablePlan
+>;
+// clang-format on
+
+struct [[nodiscard]] SqlMigrationPlan
+{
+    SqlQueryFormatter const& formatter;
+    std::vector<SqlMigrationPlanElement> steps {};
+
+    [[nodiscard]] LIGHTWEIGHT_API std::string ToSql() const;
+
+    [[nodiscard]] LIGHTWEIGHT_API static std::string ToSql(SqlQueryFormatter const& formatter,
+                                                           SqlMigrationPlanElement const& element);
+};

--- a/src/Lightweight/SqlQueryFormatter.cpp
+++ b/src/Lightweight/SqlQueryFormatter.cpp
@@ -2,7 +2,10 @@
 
 #include "SqlQueryFormatter.hpp"
 
+#include <reflection-cpp/reflection.hpp>
+
 #include <cassert>
+#include <concepts>
 #include <format>
 
 using namespace std::string_view_literals;
@@ -154,6 +157,179 @@ class BasicSqlQueryFormatter: public SqlQueryFormatter
             return std::format(
                 R"(DELETE FROM "{}" AS "{}"{}{})", fromTable, fromTableAlias, tableJoins, whereCondition);
     }
+
+    [[nodiscard]] virtual std::string BuildColumnDefinition(SqlColumnDeclaration const& column) const
+    {
+        std::stringstream sqlQueryString;
+        sqlQueryString << '"' << column.name << "\" ";
+
+        if (column.primaryKey != SqlPrimaryKeyType::AUTO_INCREMENT)
+            sqlQueryString << ColumnType(column.type);
+        else
+            sqlQueryString << ColumnType(SqlColumnTypeDefinitions::Integer {});
+
+        if (column.required)
+            sqlQueryString << " NOT NULL";
+
+        if (column.primaryKey != SqlPrimaryKeyType::NONE)
+            sqlQueryString << " PRIMARY KEY";
+        else if (column.unique && !column.index)
+            sqlQueryString << " UNIQUE";
+
+        if (column.primaryKey == SqlPrimaryKeyType::AUTO_INCREMENT)
+            sqlQueryString << " AUTOINCREMENT";
+
+        return sqlQueryString.str();
+    }
+
+    [[nodiscard]] std::string CreateTable(std::string_view tableName,
+                                          std::vector<SqlColumnDeclaration> const& columns) const override
+    {
+        std::stringstream sqlQueryString;
+
+        sqlQueryString << "CREATE TABLE \"" << tableName << "\" (";
+
+        size_t currentColumn = 0;
+        for (SqlColumnDeclaration const& column: columns)
+        {
+            if (currentColumn > 0)
+                sqlQueryString << ",";
+            ++currentColumn;
+            sqlQueryString << "\n    ";
+            sqlQueryString << BuildColumnDefinition(column);
+        }
+        sqlQueryString << "\n);";
+
+        for (SqlColumnDeclaration const& column: columns)
+        {
+            if (column.index && column.primaryKey == SqlPrimaryKeyType::NONE)
+            {
+                // primary keys are always indexed
+                if (column.unique)
+                    sqlQueryString << std::format("\nCREATE UNIQUE INDEX \"{}_{}_index\" ON \"{}\"(\"{}\");",
+                                                  tableName,
+                                                  column.name,
+                                                  tableName,
+                                                  column.name);
+                else
+                    sqlQueryString << std::format("\nCREATE INDEX \"{}_{}_index\" ON \"{}\"(\"{}\");",
+                                                  tableName,
+                                                  column.name,
+                                                  tableName,
+                                                  column.name);
+            }
+        }
+
+        return sqlQueryString.str();
+    }
+
+    [[nodiscard]] std::string AlterTable(std::string_view tableName,
+                                         std::vector<SqlAlterTableCommand> const& commands) const override
+    {
+        std::stringstream sqlQueryString;
+
+        int currentCommand = 0;
+        for (SqlAlterTableCommand const& command: commands)
+        {
+            if (currentCommand > 0)
+                sqlQueryString << '\n';
+            ++currentCommand;
+
+            sqlQueryString << std::visit(
+                [this, tableName](auto const& actualCommand) -> std::string {
+                    using Type = std::decay_t<decltype(actualCommand)>;
+                    if constexpr (std::same_as<Type, SqlAlterTableCommands::RenameTable>)
+                    {
+                        return std::format(
+                            R"(ALTER TABLE "{}" RENAME TO "{}";)", tableName, actualCommand.newTableName);
+                    }
+                    else if constexpr (std::same_as<Type, SqlAlterTableCommands::AddColumn>)
+                    {
+                        return std::format(R"(ALTER TABLE "{}" ADD COLUMN "{}" {};)",
+                                           tableName,
+                                           actualCommand.columnName,
+                                           ColumnType(actualCommand.columnType));
+                    }
+                    else if constexpr (std::same_as<Type, SqlAlterTableCommands::RenameColumn>)
+                    {
+                        return std::format(R"(ALTER TABLE "{}" RENAME COLUMN "{}" TO "{}";)",
+                                           tableName,
+                                           actualCommand.oldColumnName,
+                                           actualCommand.newColumnName);
+                    }
+                    else if constexpr (std::same_as<Type, SqlAlterTableCommands::DropColumn>)
+                    {
+                        return std::format(
+                            R"(ALTER TABLE "{}" DROP COLUMN "{}";)", tableName, actualCommand.columnName);
+                    }
+                    else if constexpr (std::same_as<Type, SqlAlterTableCommands::AddIndex>)
+                    {
+                        auto const uniqueStr = actualCommand.unique ? "UNIQUE "sv : ""sv;
+                        return std::format(R"(CREATE {2}INDEX "{0}_{1}_index" ON "{0}"("{1}");)",
+                                           tableName,
+                                           actualCommand.columnName,
+                                           uniqueStr);
+                    }
+                    else if constexpr (std::same_as<Type, SqlAlterTableCommands::DropIndex>)
+                    {
+                        return std::format(R"(DROP INDEX "{0}_{1}_index";)", tableName, actualCommand.columnName);
+                    }
+                    else
+                    {
+                        throw std::runtime_error(
+                            std::format("Unknown alter table command: {}", Reflection::TypeName<Type>));
+                    }
+                },
+                command);
+        }
+
+        return sqlQueryString.str();
+    }
+
+    [[nodiscard]] std::string ColumnType(SqlColumnTypeDefinition const& type) const override
+    {
+        using namespace SqlColumnTypeDefinitions;
+        return std::visit(
+            [](auto const& actualType) -> std::string {
+                using Type = std::decay_t<decltype(actualType)>;
+                if constexpr (std::same_as<Type, Bigint>)
+                    return "BIGINT";
+                else if constexpr (std::same_as<Type, Bool>)
+                    return "BOOLEAN";
+                else if constexpr (std::same_as<Type, Char>)
+                    return std::format("CHAR({})", actualType.size);
+                else if constexpr (std::same_as<Type, Date>)
+                    return "DATE";
+                else if constexpr (std::same_as<Type, DateTime>)
+                    return "DATETIME";
+                else if constexpr (std::same_as<Type, Decimal>)
+                    return std::format("DECIMAL({}, {})", actualType.precision, actualType.scale);
+                else if constexpr (std::same_as<Type, Guid>)
+                    return "GUID";
+                else if constexpr (std::same_as<Type, Integer>)
+                    return "INTEGER";
+                else if constexpr (std::same_as<Type, Real>)
+                    return "REAL";
+                else if constexpr (std::same_as<Type, Smallint>)
+                    return "SMALLINT";
+                else if constexpr (std::same_as<Type, Text>)
+                    return "TEXT";
+                else if constexpr (std::same_as<Type, Time>)
+                    return "TIME";
+                else if constexpr (std::same_as<Type, Timestamp>)
+                    return "TIMESTAMP";
+                else if constexpr (std::same_as<Type, Varchar>)
+                    return std::format("VARCHAR({})", actualType.size);
+                else
+                    throw std::runtime_error(std::format("Unknown column type: {}", Reflection::TypeName<Type>));
+            },
+            type);
+    }
+
+    [[nodiscard]] std::string DropTable(std::string_view const& tableName) const override
+    {
+        return std::format(R"(DROP TABLE "{}";)", tableName);
+    }
 };
 
 class SqlServerQueryFormatter final: public BasicSqlQueryFormatter
@@ -215,6 +391,85 @@ class SqlServerQueryFormatter final: public BasicSqlQueryFormatter
         sqlQueryString << " OFFSET " << offset << " ROWS FETCH NEXT " << limit << " ROWS ONLY";
         return sqlQueryString.str();
     }
+
+    [[nodiscard]] std::string ColumnType(SqlColumnTypeDefinition const& type) const override
+    {
+        using namespace SqlColumnTypeDefinitions;
+        return std::visit(
+            [this, type](auto const& actualType) -> std::string {
+                using Type = std::decay_t<decltype(actualType)>;
+                if constexpr (std::same_as<Type, Bool>)
+                    return "BIT";
+                else if constexpr (std::same_as<Type, Guid>)
+                    return "UNIQUEIDENTIFIER";
+                else if constexpr (std::same_as<Type, Text>)
+                    return "VARCHAR(MAX)";
+                else
+                    return BasicSqlQueryFormatter::ColumnType(type);
+            },
+            type);
+    }
+
+    [[nodiscard]] std::string BuildColumnDefinition(SqlColumnDeclaration const& column) const override
+    {
+        std::stringstream sqlQueryString;
+        sqlQueryString << '"' << column.name << "\" " << ColumnType(column.type);
+
+        if (column.required)
+            sqlQueryString << " NOT NULL";
+
+        if (column.primaryKey == SqlPrimaryKeyType::AUTO_INCREMENT)
+            sqlQueryString << " IDENTITY(1,1)";
+
+        if (column.primaryKey != SqlPrimaryKeyType::NONE)
+            sqlQueryString << " PRIMARY KEY";
+
+        if (column.unique && !column.index)
+            sqlQueryString << " UNIQUE";
+
+        return sqlQueryString.str();
+    }
+};
+
+class PostgreSqlFormatter final: public BasicSqlQueryFormatter
+{
+  public:
+    [[nodiscard]] std::string BuildColumnDefinition(SqlColumnDeclaration const& column) const override
+    {
+        std::stringstream sqlQueryString;
+
+        sqlQueryString << '"' << column.name << "\" ";
+
+        if (column.primaryKey == SqlPrimaryKeyType::AUTO_INCREMENT)
+            sqlQueryString << "SERIAL";
+        else
+            sqlQueryString << ColumnType(column.type);
+
+        if (column.required)
+            sqlQueryString << " NOT NULL";
+
+        if (column.primaryKey != SqlPrimaryKeyType::NONE)
+            sqlQueryString << " PRIMARY KEY";
+
+        if (column.unique && !column.index)
+            sqlQueryString << " UNIQUE";
+
+        return sqlQueryString.str();
+    }
+
+    [[nodiscard]] std::string ColumnType(SqlColumnTypeDefinition const& type) const override
+    {
+        using namespace SqlColumnTypeDefinitions;
+        return std::visit(
+            [this, type](auto const& actualType) -> std::string {
+                using Type = std::decay_t<decltype(actualType)>;
+                if constexpr (std::same_as<Type, Guid>)
+                    return "UUID";
+                else
+                    return BasicSqlQueryFormatter::ColumnType(type);
+            },
+            type);
+    }
 };
 
 } // namespace
@@ -233,7 +488,7 @@ SqlQueryFormatter const& SqlQueryFormatter::SqlServer()
 
 SqlQueryFormatter const& SqlQueryFormatter::PostgrSQL()
 {
-    static const BasicSqlQueryFormatter formatter {};
+    static const PostgreSqlFormatter formatter {};
     return formatter;
 }
 

--- a/src/Lightweight/SqlQueryFormatter.hpp
+++ b/src/Lightweight/SqlQueryFormatter.hpp
@@ -4,6 +4,7 @@
 
 #include "Api.hpp"
 #include "SqlConnection.hpp"
+#include "SqlQuery/MigrationPlan.hpp"
 
 #include <string>
 #include <string_view>
@@ -75,6 +76,11 @@ class [[nodiscard]] LIGHTWEIGHT_API SqlQueryFormatter
                                              std::string const& fromTableAlias,
                                              std::string const& tableJoins,
                                              std::string const& whereCondition) const = 0;
+
+    [[nodiscard]] virtual std::string ColumnType(SqlColumnTypeDefinition const& type) const = 0;
+    [[nodiscard]] virtual std::string CreateTable(std::string_view tableName, std::vector<SqlColumnDeclaration> const& columns) const = 0;
+    [[nodiscard]] virtual std::string AlterTable(std::string_view tableName, std::vector<SqlAlterTableCommand> const& commands) const = 0;
+    [[nodiscard]] virtual std::string DropTable(std::string_view const& tableName) const = 0;
 
     static SqlQueryFormatter const& Sqlite();
     static SqlQueryFormatter const& SqlServer();

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -177,10 +177,10 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlVariant: GetColumn in-place store variant",
     auto stmt = SqlStatement {};
     CreateEmployeesTable(stmt);
 
-    stmt.Prepare("INSERT INTO Employees (FirstName, LastName, Salary) VALUES (?, ?, ?)");
+    stmt.Prepare(R"(INSERT INTO "Employees" ("FirstName", "LastName", "Salary") VALUES (?, ?, ?))");
     stmt.Execute("Alice", SqlNullValue, 50'000);
 
-    stmt.ExecuteDirect("SELECT FirstName, LastName, Salary FROM Employees");
+    stmt.ExecuteDirect(R"(SELECT "FirstName", "LastName", "Salary" FROM "Employees")");
     (void) stmt.FetchRow();
 
     CHECK(stmt.GetColumn<std::string>(1) == "Alice");


### PR DESCRIPTION
Refs #6

### checklist (query builder)

each item should have its own test

- [x] `CreateTable()`
- [x] `DropTable()`
- [x] `AlterTable()`
- [x] AlterTable: RenameTable
- [x] AlterTable: RenameColumn
- [x] AlterTable: AddColumn
- [x] AlterTable: DropColumn
- [x] AlterTable: AddIndex
- [x] AlterTable: DropIndex
- [x] make use of Migration query builder in existing tests to avoid writing raw CREATE TABLE statements.

based on that, we can build a DB migration API that makes use of the fluent API to express schema changes.
