### PR TITLE
SqlConnection: Default to SQL connection string and be more explicit about it

### DIFF
--- a/src/Lightweight/DataMapper/DataMapper.hpp
+++ b/src/Lightweight/DataMapper/DataMapper.hpp
@@ -397,7 +397,7 @@ RecordId DataMapper::Create(Record& record)
         if constexpr (!PrimaryKeyType::IsAutoIncrementPrimaryKey)
         {
             using ValueType = typename PrimaryKeyType::ValueType;
-            if constexpr (requires { ValueType{} + 1; })
+            if constexpr (requires { ValueType {} + 1; })
             {
                 if (!primaryKeyField.IsModified())
                 {
@@ -869,12 +869,13 @@ void DataMapper::BindOutputColumns(Record& record, SqlStatement* stmt)
     assert(stmt != nullptr);
     static_assert(!std::is_const_v<Record>);
 
-    Reflection::EnumerateMembers(record, [this, stmt, i = 1]<size_t I, typename Field>(Field& field) mutable {
-        if constexpr (FieldWithStorage<Field>)
-        {
-            field.BindOutputColumn(i++, *stmt);
-        }
-    });
+    Reflection::EnumerateMembers(record,
+                                 [this, stmt, i = SQLSMALLINT { 1 }]<size_t I, typename Field>(Field& field) mutable {
+                                     if constexpr (FieldWithStorage<Field>)
+                                     {
+                                         field.BindOutputColumn(i++, *stmt);
+                                     }
+                                 });
 }
 
 template <typename Record>

--- a/src/Lightweight/SqlConnectInfo.hpp
+++ b/src/Lightweight/SqlConnectInfo.hpp
@@ -29,6 +29,15 @@ struct SqlConnectionDataSource
     std::string password;
     std::chrono::seconds timeout { 5 };
 
+    [[nodiscard]] SqlConnectionString ToConnectionString() const
+    {
+        return SqlConnectionString { .value = std::format("DSN={};UID={};PWD={};TIMEOUT={}",
+                                                          datasource,
+                                                          username,
+                                                          password,
+                                                          timeout.count()) };
+    }
+
     LIGHTWEIGHT_API auto operator<=>(SqlConnectionDataSource const&) const noexcept = default;
 };
 

--- a/src/Lightweight/SqlConnection.hpp
+++ b/src/Lightweight/SqlConnection.hpp
@@ -43,7 +43,7 @@ class LIGHTWEIGHT_API SqlConnection final
     SqlConnection();
 
     // Constructs a new SQL connection to the given connect informaton.
-    explicit SqlConnection(std::optional<SqlConnectInfo> connectInfo);
+    explicit SqlConnection(std::optional<SqlConnectionString> connectInfo);
 
     SqlConnection(SqlConnection&& /*other*/) noexcept;
     SqlConnection& operator=(SqlConnection&& /*other*/) noexcept;
@@ -54,10 +54,11 @@ class LIGHTWEIGHT_API SqlConnection final
     ~SqlConnection() noexcept;
 
     // Retrieves the default connection information.
-    static SqlConnectInfo const& DefaultConnectInfo() noexcept;
+    static SqlConnectionString const& DefaultConnectionString() noexcept;
 
     // Sets the default connection information.
-    static void SetDefaultConnectInfo(SqlConnectInfo connectInfo) noexcept;
+    static void SetDefaultConnectionString(SqlConnectionString const& connectionString) noexcept;
+    static void SetDefaultDataSource(SqlConnectionDataSource const& dataSource) noexcept;
 
     static void SetPostConnectedHook(std::function<void(SqlConnection&)> hook);
     static void ResetPostConnectedHook();
@@ -78,19 +79,13 @@ class LIGHTWEIGHT_API SqlConnection final
     //
     // @retval true if the connection was successful.
     // @retval false if the connection failed. Use LastError() to retrieve the error information.
-    bool Connect(std::string_view datasource, std::string_view username, std::string_view password) noexcept;
-
-    // Connects to the given database with the given ODBC connection string.
-    //
-    // @retval true if the connection was successful.
-    // @retval false if the connection failed. Use LastError() to retrieve the error information.
-    bool Connect(std::string connectionString) noexcept;
+    bool Connect(SqlConnectionDataSource const& info) noexcept;
 
     // Connects to the given database with the given username and password.
     //
     // @retval true if the connection was successful.
     // @retval false if the connection failed. Use LastError() to retrieve the error information.
-    bool Connect(SqlConnectInfo connectInfo) noexcept;
+    bool Connect(SqlConnectionString sqlConnectionString) noexcept;
 
     // Retrieves the last error information with respect to this SQL connection handle.
     [[nodiscard]] SqlErrorInfo LastError() const;
@@ -135,7 +130,7 @@ class LIGHTWEIGHT_API SqlConnection final
     [[nodiscard]] bool IsAlive() const noexcept;
 
     // Retrieves the connection information.
-    [[nodiscard]] SqlConnectInfo const& ConnectionInfo() const noexcept;
+    [[nodiscard]] SqlConnectionString const& ConnectionString() const noexcept;
 
     // Retrieves the native handle.
     [[nodiscard]] SQLHDBC NativeHandle() const noexcept

--- a/src/Lightweight/SqlLogger.cpp
+++ b/src/Lightweight/SqlLogger.cpp
@@ -145,14 +145,14 @@ class SqlTraceLogger: public SqlStandardLogger
     {
         _state = State::Idle;
         Tick();
-        WriteMessage("Connection {} opened: {}", connection.ConnectionId(), connection.ConnectionInfo());
+        WriteMessage("Connection {} opened: {}", connection.ConnectionId(), connection.ConnectionString().value);
     }
 
     void OnConnectionClosed(SqlConnection const& connection) override
     {
         _state = State::Idle;
         Tick();
-        WriteMessage("Connection {} closed: {}", connection.ConnectionId(), connection.ConnectionInfo());
+        WriteMessage("Connection {} closed: {}", connection.ConnectionId(), connection.ConnectionString().value);
     }
 
     void OnConnectionIdle(SqlConnection const& /*connection*/) override

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -575,8 +575,7 @@ inline LIGHTWEIGHT_FORCE_INLINE void SqlStatement::ExecuteDirect(SqlQueryObject 
 
 template <typename T>
     requires(!std::same_as<T, SqlVariant>)
-inline LIGHTWEIGHT_FORCE_INLINE std::optional<T> SqlStatement::ExecuteDirectScalar(const std::string_view& query,
-                                                                                   std::source_location location)
+inline std::optional<T> SqlStatement::ExecuteDirectScalar(const std::string_view& query, std::source_location location)
 {
     auto const _ = detail::Finally([this] { CloseCursor(); });
     ExecuteDirect(query, location);
@@ -586,8 +585,7 @@ inline LIGHTWEIGHT_FORCE_INLINE std::optional<T> SqlStatement::ExecuteDirectScal
 
 template <typename T>
     requires(std::same_as<T, SqlVariant>)
-inline LIGHTWEIGHT_FORCE_INLINE T SqlStatement::ExecuteDirectScalar(const std::string_view& query,
-                                                                    std::source_location location)
+inline T SqlStatement::ExecuteDirectScalar(const std::string_view& query, std::source_location location)
 {
     auto const _ = detail::Finally([this] { CloseCursor(); });
     ExecuteDirect(query, location);
@@ -599,16 +597,15 @@ inline LIGHTWEIGHT_FORCE_INLINE T SqlStatement::ExecuteDirectScalar(const std::s
 
 template <typename T>
     requires(!std::same_as<T, SqlVariant>)
-inline LIGHTWEIGHT_FORCE_INLINE std::optional<T> SqlStatement::ExecuteDirectScalar(SqlQueryObject auto const& query,
-                                                                                   std::source_location location)
+inline std::optional<T> SqlStatement::ExecuteDirectScalar(SqlQueryObject auto const& query,
+                                                          std::source_location location)
 {
     return ExecuteDirectScalar<T>(query.ToSql(), location);
 }
 
 template <typename T>
     requires(std::same_as<T, SqlVariant>)
-inline LIGHTWEIGHT_FORCE_INLINE T SqlStatement::ExecuteDirectScalar(SqlQueryObject auto const& query,
-                                                                    std::source_location location)
+inline T SqlStatement::ExecuteDirectScalar(SqlQueryObject auto const& query, std::source_location location)
 {
     return ExecuteDirectScalar<T>(query.ToSql(), location);
 }

--- a/src/benchmark/benchmark.cpp
+++ b/src/benchmark/benchmark.cpp
@@ -71,13 +71,13 @@ class SqlTestFixture
 
         {
             std::println("Using ODBC connection string: '{}'", SanitizePwd(s));
-            SqlConnection::SetDefaultConnectInfo(SqlConnectionString { s });
+            SqlConnection::SetDefaultConnectionString(SqlConnectionString { s });
         }
         else
         {
             // Use an in-memory SQLite3 database by default (for testing purposes)
             std::println("Using default ODBC connection string: '{}'", DefaultTestConnectionString.value);
-            SqlConnection::SetDefaultConnectInfo(DefaultTestConnectionString);
+            SqlConnection::SetDefaultConnectionString(DefaultTestConnectionString);
         }
 
         auto sqlConnection = SqlConnection();

--- a/src/tests/CoreTests.cpp
+++ b/src/tests/CoreTests.cpp
@@ -280,7 +280,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlConnection: manual connect")
     auto conn = SqlConnection { std::nullopt };
     REQUIRE(!conn.IsAlive());
 
-    CHECK(conn.Connect(SqlConnection::DefaultConnectInfo()));
+    CHECK(conn.Connect(SqlConnection::DefaultConnectionString()));
     CHECK(conn.IsAlive());
 }
 

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -537,8 +537,7 @@ TEMPLATE_LIST_TEST_CASE("SqlDataBinder specializations", "[SqlDataBinder]", Type
 
         // Connecting to the database (using the default connection) the verbose way,
         // purely to demonstrate how to do it.
-        auto connectionInfo = SqlConnection::DefaultConnectInfo();
-        auto conn = SqlConnection { connectionInfo };
+        auto conn = SqlConnection { SqlConnection::DefaultConnectionString() };
 
         if constexpr (requires { TestTypeTraits<TestType>::blacklist; })
         {

--- a/src/tests/DataMapperTests.cpp
+++ b/src/tests/DataMapperTests.cpp
@@ -39,7 +39,7 @@ std::ostream& operator<<(std::ostream& os, Field<T, IsPrimaryKeyValue> const& fi
 
 struct Person
 {
-    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<uint64_t, PrimaryKey::AutoIncrement> id;
     Field<SqlTrimmedFixedString<25>> name;
     Field<bool> is_active { true };
     Field<std::optional<int>> age;
@@ -48,7 +48,7 @@ struct Person
 // This is a test to only partially query a table row (a few columns)
 struct PersonName
 {
-    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<uint64_t, PrimaryKey::AutoIncrement> id;
     Field<SqlTrimmedFixedString<25>> name;
 
     static constexpr std::string_view TableName = RecordTableName<Person>;
@@ -113,7 +113,7 @@ TEST_CASE_METHOD(SqlTestFixture, "partial row retrieval", "[DataMapper]")
 
 struct RecordWithDefaults
 {
-    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<uint64_t, PrimaryKey::AutoIncrement> id;
     Field<std::string> name1 { "John Doe" };
     Field<std::optional<std::string>> name2 { "John Doe" };
     Field<bool> boolean1 { true };
@@ -124,7 +124,7 @@ struct RecordWithDefaults
 
 struct RecordWithNoDefaults
 {
-    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<uint64_t, PrimaryKey::AutoIncrement> id;
     Field<std::string> name1;
     Field<std::optional<std::string>> name2;
     Field<bool> boolean1;
@@ -159,7 +159,7 @@ struct Email;
 
 struct User
 {
-    Field<int, PrimaryKey::AutoIncrement> id {};
+    Field<uint64_t, PrimaryKey::AutoIncrement> id {};
     Field<std::string> name {};
 
     HasMany<Email> emails {};
@@ -167,7 +167,7 @@ struct User
 
 struct Email
 {
-    Field<int, PrimaryKey::AutoIncrement> id {};
+    Field<uint64_t, PrimaryKey::AutoIncrement> id {};
     Field<std::string> address {};
     BelongsTo<&User::id> user {};
 
@@ -270,7 +270,7 @@ struct AccountHistory;
 
 struct Suppliers
 {
-    Field<int, PrimaryKey::AutoIncrement> id {};
+    Field<uint64_t, PrimaryKey::AutoIncrement> id {};
     Field<std::string> name {};
 
     // TODO: HasOne<Account> account;
@@ -284,7 +284,7 @@ std::ostream& operator<<(std::ostream& os, Suppliers const& record)
 
 struct Account
 {
-    Field<int, PrimaryKey::AutoIncrement> id {};
+    Field<uint64_t, PrimaryKey::AutoIncrement> id {};
     Field<std::string> iban {};
     BelongsTo<&Suppliers::id> supplier {};
 
@@ -298,7 +298,7 @@ std::ostream& operator<<(std::ostream& os, Account const& record)
 
 struct AccountHistory
 {
-    Field<int, PrimaryKey::AutoIncrement> id {};
+    Field<uint64_t, PrimaryKey::AutoIncrement> id {};
     Field<int> credit_rating {};
     BelongsTo<&Account::id> account {};
 
@@ -349,7 +349,7 @@ struct Patient;
 
 struct Physician
 {
-    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<uint64_t, PrimaryKey::AutoIncrement> id;
     Field<std::string> name;
     HasMany<Appointment> appointments;
     HasManyThrough<Patient, Appointment> patients;
@@ -357,7 +357,7 @@ struct Physician
 
 struct Patient
 {
-    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<uint64_t, PrimaryKey::AutoIncrement> id;
     Field<std::string> name;
     Field<std::string> comment;
     HasMany<Appointment> appointments;
@@ -366,7 +366,7 @@ struct Patient
 
 struct Appointment
 {
-    Field<int, PrimaryKey::AutoIncrement> id;
+    Field<uint64_t, PrimaryKey::AutoIncrement> id;
     Field<SqlDateTime> date;
     Field<std::string> comment;
     BelongsTo<&Physician::id> physician;
@@ -453,7 +453,7 @@ TEST_CASE_METHOD(SqlTestFixture, "HasManyThrough", "[DataMapper][relations]")
 
 struct TestRecord
 {
-    Field<int, PrimaryKey::Manual> id {};
+    Field<uint64_t, PrimaryKey::Manual> id {};
     Field<std::string> comment;
 
     std::weak_ordering operator<=>(TestRecord const& other) const = default;

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -132,7 +132,7 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.FieldsForFieldMembers", "[SqlQ
                          });
 }
 
-struct Email
+struct QueryBuilderTestEmail
 {
     Field<std::string> email;
     BelongsTo<&UsersFields::name> user;
@@ -140,11 +140,14 @@ struct Email
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.FieldsWithBelongsTo", "[SqlQueryBuilder]")
 {
-    checkSqlQueryBuilder([](SqlQueryBuilder& q) { return q.FromTable("Email").Select().Fields<Email>().First(); },
-                         QueryExpectations {
-                             .sqlite = R"(SELECT "email", "user" FROM "Email" LIMIT 1)",
-                             .sqlServer = R"(SELECT TOP 1 "email", "user" FROM "Email")",
-                         });
+    checkSqlQueryBuilder(
+        [](SqlQueryBuilder& q) {
+            return q.FromTable("QueryBuilderTestEmail").Select().Fields<QueryBuilderTestEmail>().First();
+        },
+        QueryExpectations {
+            .sqlite = R"(SELECT "email", "user" FROM "QueryBuilderTestEmail" LIMIT 1)",
+            .sqlServer = R"(SELECT TOP 1 "email", "user" FROM "QueryBuilderTestEmail")",
+        });
 }
 
 TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.Where.Junctors", "[SqlQueryBuilder]")

--- a/src/tests/QueryBuilderTests.cpp
+++ b/src/tests/QueryBuilderTests.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "Utils.hpp"
+
 #include <Lightweight/DataMapper/DataMapper.hpp>
 
 #include <catch2/catch_session.hpp>
@@ -131,7 +132,8 @@ TEST_CASE_METHOD(SqlTestFixture, "SqlQueryBuilder.FieldsForFieldMembers", "[SqlQ
                          });
 }
 
-struct Email{
+struct Email
+{
     Field<std::string> email;
     BelongsTo<&UsersFields::name> user;
 };

--- a/src/tests/Utils.hpp
+++ b/src/tests/Utils.hpp
@@ -268,13 +268,13 @@ class SqlTestFixture
 
         {
             std::println("Using ODBC connection string: '{}'", SanitizePwd(s));
-            SqlConnection::SetDefaultConnectInfo(SqlConnectionString { s });
+            SqlConnection::SetDefaultConnectionString(SqlConnectionString { s });
         }
         else
         {
             // Use an in-memory SQLite3 database by default (for testing purposes)
             std::println("Using default ODBC connection string: '{}'", DefaultTestConnectionString.value);
-            SqlConnection::SetDefaultConnectInfo(DefaultTestConnectionString);
+            SqlConnection::SetDefaultConnectionString(DefaultTestConnectionString);
         }
 
         SqlConnection::SetPostConnectedHook(&SqlTestFixture::PostConnectedHook);

--- a/src/tools/ddl2cpp.cpp
+++ b/src/tools/ddl2cpp.cpp
@@ -382,7 +382,7 @@ int main(int argc, char const* argv[])
         return *exitCode;
     auto const config = std::get<Configuration>(configOpt);
 
-    SqlConnection::SetDefaultConnectInfo(SqlConnectionString { std::string(config.connectionString) });
+    SqlConnection::SetDefaultConnectionString(SqlConnectionString { std::string(config.connectionString) });
     SqlConnection::SetPostConnectedHook(&PostConnectedHook);
 
     if (config.createTestTables)


### PR DESCRIPTION
FYI: we had serious issues with that gDefaultConnectionInfo-global when this library was built as DLL on Windows. So we decided to be more explicit about it, only allow connection strings as default way, but still allow data sources to be passed (explicitly only) and converted to connection strings, when explicitely requested.