### PR TITLE
trimmed (fixed) string related bug fixes and a new constructor overload for SqlStatement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       run: |
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh 19
+        sudo ./llvm.sh 20
         sudo apt -qy install clang-tidy
     - name: "install dependencies"
       run: sudo apt install -y cmake ninja-build catch2 unixodbc-dev sqlite3 libsqlite3-dev libsqliteodbc uuid-dev

--- a/src/Lightweight/DataBinder/SqlFixedString.hpp
+++ b/src/Lightweight/DataBinder/SqlFixedString.hpp
@@ -167,15 +167,13 @@ class SqlFixedString
     LIGHTWEIGHT_FORCE_INLINE std::weak_ordering operator<=>(
         SqlFixedString<OtherSize, T, OtherPostOp> const& other) const noexcept
     {
-        if ((void*) this != (void*) &other)
-        {
-            for (std::size_t i = 0; i < (std::min)(size(), other.size()); ++i)
-                if (auto const cmp = _data[i] <=> other._data[i]; cmp != std::weak_ordering::equivalent)
-                    return cmp;
-            if constexpr (N != OtherSize)
-                return N <=> OtherSize;
-        }
-        return std::weak_ordering::equivalent;
+        if ((void*) this == (void*) &other) [[unlikely]]
+            return std::weak_ordering::equivalent;
+
+        for (std::size_t i = 0; i < (std::min)(size(), other.size()); ++i)
+            if (auto const cmp = _data[i] <=> other._data[i]; cmp != std::weak_ordering::equivalent) [[unlikely]]
+                return cmp;
+        return size() <=> other.size();
     }
 
     template <std::size_t OtherSize, SqlStringPostRetrieveOperation OtherPostOp>

--- a/src/Lightweight/DataBinder/SqlFixedString.hpp
+++ b/src/Lightweight/DataBinder/SqlFixedString.hpp
@@ -228,7 +228,7 @@ struct SqlDataBinder<SqlFixedString<N, T, PostOp>>
 
     LIGHTWEIGHT_FORCE_INLINE static void TrimRight(ValueType* boundOutputString, SQLLEN indicator) noexcept
     {
-        size_t n = (std::min)((size_t) indicator, boundOutputString->size());
+        size_t n = (std::min)((size_t) indicator, N - 1);
         while (n > 0 && std::isspace((*boundOutputString)[n - 1]))
             --n;
         boundOutputString->setsize(n);

--- a/src/Lightweight/DataBinder/SqlTrimmedString.hpp
+++ b/src/Lightweight/DataBinder/SqlTrimmedString.hpp
@@ -8,6 +8,7 @@
 #include <compare>
 #include <format>
 #include <string>
+#include <utility>
 
 // Helper struct to store a string that should be automatically trimmed when fetched from the database.
 // This is only needed for compatibility with old columns that hard-code the length, like CHAR(50).

--- a/src/Lightweight/DataBinder/SqlTrimmedString.hpp
+++ b/src/Lightweight/DataBinder/SqlTrimmedString.hpp
@@ -60,6 +60,20 @@ struct SqlDataBinder<SqlTrimmedString>
                                                            SQLLEN* indicator,
                                                            SqlDataBinderCallback& cb) noexcept
     {
+        SQLULEN columnSize {};
+        auto const describeResult = SQLDescribeCol(stmt,
+                                                   column,
+                                                   nullptr /*colName*/,
+                                                   0 /*sizeof(colName)*/,
+                                                   nullptr /*&colNameLen*/,
+                                                   nullptr /*&dataType*/,
+                                                   &columnSize,
+                                                   nullptr /*&decimalDigits*/,
+                                                   nullptr /*&nullable*/);
+        if (!SQL_SUCCEEDED(describeResult))
+            return describeResult;
+        result->value.resize(columnSize);
+
         auto* boundOutputString = &result->value;
         cb.PlanPostProcessOutputColumn([indicator, boundOutputString]() {
             // NB: If the indicator is greater than the buffer size, we have a truncation.

--- a/src/Lightweight/SqlStatement.cpp
+++ b/src/Lightweight/SqlStatement.cpp
@@ -9,7 +9,11 @@ struct SqlStatement::Data
     std::vector<SQLLEN> indicators;               // Holds the indicators for the bound output columns
     std::vector<std::function<void()>> postExecuteCallbacks;
     std::vector<std::function<void()>> postProcessOutputColumnCallbacks;
+
+    static Data const NoData;
 };
+
+SqlStatement::Data const SqlStatement::Data::NoData {};
 
 void SqlStatement::RequireIndicators()
 {
@@ -103,6 +107,12 @@ SqlStatement::SqlStatement(SqlConnection& relatedConnection):
     m_connection { &relatedConnection }
 {
     RequireSuccess(SQLAllocHandle(SQL_HANDLE_STMT, m_connection->NativeHandle(), &m_hStmt));
+}
+
+SqlStatement::SqlStatement(std::nullopt_t /*nullopt*/):
+    m_data { const_cast<Data*>(&Data::NoData), [](Data* /*data*/) {
+            } }
+{
 }
 
 SqlStatement::~SqlStatement() noexcept

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -58,6 +58,9 @@ class SqlStatement final: public SqlDataBinderCallback
     // Construct a new SqlStatement object, using the given connection.
     LIGHTWEIGHT_API explicit SqlStatement(SqlConnection& relatedConnection);
 
+    // Construct a new empty SqlStatement object. No SqlConnection is associated with this statement.
+    LIGHTWEIGHT_API explicit SqlStatement(std::nullopt_t /*nullopt*/);
+
     LIGHTWEIGHT_API ~SqlStatement() noexcept final;
 
     [[nodiscard]] LIGHTWEIGHT_API bool IsAlive() const noexcept;

--- a/src/Lightweight/SqlStatement.hpp
+++ b/src/Lightweight/SqlStatement.hpp
@@ -14,6 +14,7 @@
 #include "Utils.hpp"
 
 #include <cstring>
+#include <expected>
 #include <optional>
 #include <ranges>
 #include <source_location>
@@ -199,6 +200,9 @@ class SqlStatement final: public SqlDataBinderCallback
     // @retval true The next result row was successfully fetched
     // @retval false No result row was fetched, because the end of the result set was reached.
     [[nodiscard]] LIGHTWEIGHT_API bool FetchRow();
+
+    [[nodiscard]] LIGHTWEIGHT_API std::expected<bool, SqlErrorInfo> TryFetchRow(
+        std::source_location location = std::source_location::current()) noexcept;
 
     // Closes the result cursor on queries that yield a result set, e.g. SELECT statements.
     //

--- a/src/tests/CoreTests.cpp
+++ b/src/tests/CoreTests.cpp
@@ -40,6 +40,19 @@ int main(int argc, char** argv)
     return Catch::Session().run(argc, argv);
 }
 
+TEST_CASE_METHOD(SqlTestFixture, "SqlStatement: ctor std::nullopt")
+{
+    // Construct an empty SqlStatement, not referencing any SqlConnection. 
+    auto stmt = SqlStatement { std::nullopt };
+    REQUIRE(!stmt.IsAlive());
+    CHECK_THROWS(!stmt.ExecuteDirectScalar<int>("SELECT 42").has_value());
+
+    // Get `stmt` valid by assigning it a valid SqlStatement
+    stmt = SqlStatement {};
+    REQUIRE(stmt.IsAlive());
+    CHECK(stmt.ExecuteDirectScalar<int>("SELECT 42").value() == 42);
+}
+
 TEST_CASE_METHOD(SqlTestFixture, "select: get columns")
 {
     auto stmt = SqlStatement {};

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -439,12 +439,12 @@ struct TestTypeTraits<CustomType>
 };
 
 template <>
-struct TestTypeTraits<SqlFixedString<8, char, SqlStringPostRetrieveOperation::TRIM_RIGHT>>
+struct TestTypeTraits<SqlFixedString<20, char, SqlStringPostRetrieveOperation::TRIM_RIGHT>>
 {
-    using ValueType = SqlFixedString<8, char, SqlStringPostRetrieveOperation::TRIM_RIGHT>;
-    static constexpr auto cTypeName = "SqlFixedString<8, char, TRIM_RIGHT>";
+    using ValueType = SqlFixedString<20, char, SqlStringPostRetrieveOperation::TRIM_RIGHT>;
+    static constexpr auto cTypeName = "SqlFixedString<20, char, TRIM_RIGHT>";
     static constexpr auto sqlColumnTypeNameOverride = "CHAR(8)";
-    static constexpr auto inputValue = ValueType { "Hello" };
+    static constexpr auto inputValue = ValueType { "Hello " };
     static constexpr auto expectedOutputValue = ValueType { "Hello" };
 };
 
@@ -513,7 +513,7 @@ using TypesToTest = std::tuple<
    CustomType,
    SqlDate,
    SqlDateTime,
-   SqlFixedString<8, char, SqlStringPostRetrieveOperation::TRIM_RIGHT>,
+   SqlFixedString<20, char, SqlStringPostRetrieveOperation::TRIM_RIGHT>,
    SqlGuid,
    SqlNumeric<15, 2>,
    SqlText,

--- a/src/tests/DataBinderTests.cpp
+++ b/src/tests/DataBinderTests.cpp
@@ -507,7 +507,6 @@ struct TestTypeTraits<SqlTrimmedString>
     static constexpr auto sqlColumnTypeNameOverride = "VARCHAR(50)";
     static auto const inline inputValue = SqlTrimmedString { "Alice    " };
     static auto const inline expectedOutputValue = SqlTrimmedString { "Alice" };
-    static auto const inline outputInitializer = SqlTrimmedString { std::string(50, '\0') };
 };
 
 using TypesToTest = std::tuple<

--- a/src/tests/DataMapperTests.cpp
+++ b/src/tests/DataMapperTests.cpp
@@ -126,7 +126,7 @@ TEST_CASE_METHOD(SqlTestFixture, "iterate over database", "[SqlRowIterator]")
 
     auto stmt = SqlStatement { dm.Connection() };
     int age = 40;
-    int id = 1;
+    std::uint64_t id = 1;
     for (auto&& person: SqlRowIterator<Person>(stmt))
     {
         CHECK(person.name.Value() == "John");


### PR DESCRIPTION
* Add constructor `SqlStatement(std::nullopt_t)`
* Add `std::expected<bool, SqlErrorInfo> SqlStatement::TryFetchRow() noexcept`
* Fix `SqlFixedString::operator<=>`
* Fix `SqlFixedString`'s right trimming
* Change `SqlTrimmedString` to not require pre-reserving underlying memory
* test cases adapted accordingly