### PR TITLE
SqlStatement: Fix superfluous return statement, causing some compilers to bail out

### DIFF
--- a/src/Lightweight/SqlStatement.cpp
+++ b/src/Lightweight/SqlStatement.cpp
@@ -228,7 +228,6 @@ std::expected<bool, SqlErrorInfo> SqlStatement::TryFetchRow(std::source_location
             SqlLogger::GetLogger().OnFetchRow();
             return true;
     }
-    return true;
 }
 
 void SqlStatement::RequireSuccess(SQLRETURN error, std::source_location sourceLocation) const


### PR DESCRIPTION
MSVC (VS2022) actually. Why did we not hit this in our CI? ;-(